### PR TITLE
feat: join atoma-node's handles

### DIFF
--- a/atoma-node/src/atoma_node.rs
+++ b/atoma-node/src/atoma_node.rs
@@ -10,10 +10,14 @@ use atoma_sui::subscriber::{SuiSubscriber, SuiSubscriberError};
 use atoma_types::{Request, Response};
 use thiserror::Error;
 use tokio::{
-    sync::{mpsc, mpsc::Receiver, oneshot},
+    sync::{
+        mpsc::{self, Receiver},
+        oneshot,
+    },
     task::JoinHandle,
+    try_join,
 };
-use tracing::info;
+use tracing::{error, info};
 
 const ATOMA_OUTPUT_MANAGER_FIREBASE_URL: &str = "https://atoma-demo-default-rtdb.firebaseio.com/"; // TODO: this is only valid for demo
 const CHANNEL_SIZE: usize = 32;
@@ -31,7 +35,7 @@ impl AtomaNode {
         model_config_path: P,
         sui_subscriber_path: P,
         json_server_req_rx: Receiver<(Request, oneshot::Sender<Response>)>,
-    ) -> Result<Self, AtomaNodeError>
+    ) -> Result<(), AtomaNodeError>
     where
         P: AsRef<Path> + Send + 'static,
     {
@@ -90,12 +94,29 @@ impl AtomaNode {
                 .map_err(AtomaNodeError::AtomaOutputManagerError)
         });
 
-        Ok(Self {
+        match try_join!(
             model_service_handle,
             sui_subscriber_handle,
             atoma_sui_client_handle,
-            atoma_output_manager_handle,
-        })
+            atoma_output_manager_handle
+        ) {
+            Ok((
+                model_service_result,
+                sui_subscriber_result,
+                atoma_sui_client_result,
+                atoma_output_manager_result,
+            )) => {
+                model_service_result?;
+                sui_subscriber_result?;
+                atoma_sui_client_result?;
+                atoma_output_manager_result?;
+            }
+            Err(e) => {
+                error!("Failed to join handles, with error: {e}")
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/atoma-node/src/main.rs
+++ b/atoma-node/src/main.rs
@@ -32,5 +32,5 @@ async fn main() -> Result<(), AtomaNodeError> {
     )
     .await?;
 
-    loop {}
+    Ok(())
 }


### PR DESCRIPTION
**Description:**

- [x] Refactors the `AtomaNode`'s `start` method to try to join on all handles (of each of its subcomponents). In this way, awaiting on `start` leads to the termination of each of spawned tasks (if okay) or to an error, if some of the tasks errors.