### PR TITLE
feat: merge config

### DIFF
--- a/atoma-client/src/config.rs
+++ b/atoma-client/src/config.rs
@@ -25,7 +25,7 @@ impl AtomaSuiClientConfig {
             .build()
             .expect("Failed to generate Atoma Sui client configuration file");
         config
-            .try_deserialize::<Self>()
+            .get::<Self>("client")
             .expect("Failed to generated Atoma Sui client config file")
     }
 

--- a/atoma-event-subscribe/sui/src/config.rs
+++ b/atoma-event-subscribe/sui/src/config.rs
@@ -59,7 +59,7 @@ impl SuiSubscriberConfig {
             .build()
             .expect("Failed to generate inference configuration file");
         config
-            .try_deserialize::<Self>()
+            .get::<Self>("event_subscriber")
             .expect("Failed to generated config file")
     }
 }

--- a/atoma-inference/src/models/config.rs
+++ b/atoma-inference/src/models/config.rs
@@ -116,7 +116,7 @@ impl ModelsConfig {
             .build()
             .expect("Failed to generate inference configuration file");
         config
-            .try_deserialize::<Self>()
+            .get::<Self>("inference")
             .expect("Failed to generated config file")
     }
 

--- a/atoma-node/src/main.rs
+++ b/atoma-node/src/main.rs
@@ -7,13 +7,7 @@ const CHANNEL_BUFFER: usize = 32;
 #[derive(Debug, Parser)]
 struct Args {
     #[arg(long)]
-    atoma_sui_client_config_path: String,
-    #[arg(long)]
-    model_config_path: String,
-    #[arg(long)]
-    sui_subscriber_path: String,
-    #[arg(long)]
-    output_manager_config_path: String,
+    config_path: String,
 }
 
 #[tokio::main]
@@ -21,20 +15,10 @@ async fn main() -> Result<(), AtomaNodeError> {
     tracing_subscriber::fmt::init();
 
     let args = Args::parse();
-    let atoma_sui_client_config_path = args.atoma_sui_client_config_path;
-    let model_config_path = args.model_config_path;
-    let sui_subscriber_path = args.sui_subscriber_path;
-    let output_manager_config_path = args.output_manager_config_path;
+    let config_path = args.config_path;
 
     let (_, json_rpc_server_rx) = mpsc::channel(CHANNEL_BUFFER);
-    AtomaNode::start(
-        atoma_sui_client_config_path,
-        model_config_path,
-        sui_subscriber_path,
-        output_manager_config_path,
-        json_rpc_server_rx,
-    )
-    .await?;
+    AtomaNode::start(config_path, json_rpc_server_rx).await?;
 
     Ok(())
 }

--- a/atoma-output-manager/src/config.rs
+++ b/atoma-output-manager/src/config.rs
@@ -18,7 +18,7 @@ impl AtomaFirebaseConfig {
             .build()
             .expect("Failed to generate Atoma Sui client configuration file");
         config
-            .try_deserialize::<Self>()
+            .get::<Self>("output_manager")
             .expect("Failed to generated Atoma Sui client config file")
     }
 

--- a/atoma-output-manager/src/lib.rs
+++ b/atoma-output-manager/src/lib.rs
@@ -28,8 +28,8 @@ impl AtomaOutputManager {
         }
     }
 
-    pub fn new_from_config(
-        config_path: &Path,
+    pub fn new_from_config<P: AsRef<Path>>(
+        config_path: P,
         output_manager_rx: mpsc::Receiver<(Digest, Response)>,
     ) -> Self {
         let config = AtomaFirebaseConfig::from_file_path(config_path);


### PR DESCRIPTION
Merge config into one (argument is now `config_path`). The sections are named after the cargo projects
- `client`
- `event_subscriber`
- `inference`
- `output_manager`