### PR TITLE
feat: change sqlite to any

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The application uses a TOML configuration file with the following sections:
 - `sui_keystore_path`: Path to the Sui keystore file, it should be at the same directory level as the Sui configuration file.
 
 ##### `[atoma-state]`
-- `database_url`: SQLite database connection URL
+- `database_url`: any database connection URL
 
 ##### Example Configuration
 

--- a/atoma-state/Cargo.toml
+++ b/atoma-state/Cargo.toml
@@ -10,7 +10,7 @@ config = { workspace = true }
 flume = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "sqlite"] }
+sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "sqlite", "any"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/atoma-state/src/config.rs
+++ b/atoma-state/src/config.rs
@@ -2,7 +2,7 @@ use config::Config;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// Configuration for SQLite database connection.
+/// Configuration for any database connection.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AtomaStateManagerConfig {
     /// The URL of the SQLite database.

--- a/atoma-state/src/lib.rs
+++ b/atoma-state/src/lib.rs
@@ -4,8 +4,8 @@ pub mod state_manager;
 pub mod types;
 
 pub use config::AtomaStateManagerConfig;
-use sqlx::Sqlite;
-pub use sqlx::SqlitePool;
+use sqlx::Any;
+pub use sqlx::AnyPool;
 pub use state_manager::{AtomaState, AtomaStateManager, AtomaStateManagerError};
 
 /// Builds a query with an IN clause and optional additional conditions

--- a/atoma-state/src/lib.rs
+++ b/atoma-state/src/lib.rs
@@ -18,12 +18,12 @@ pub use state_manager::{AtomaState, AtomaStateManager, AtomaStateManagerError};
 ///
 /// # Returns
 /// A QueryBuilder configured with the IN clause and ready for additional bindings
-pub(crate) fn build_query_with_in<'a, T: sqlx::Type<Sqlite> + sqlx::Encode<'a, Sqlite>>(
+pub(crate) fn build_query_with_in<'a, T: sqlx::Type<Any> + sqlx::Encode<'a, Any>>(
     base_query: &str,
     column: &str,
     values: &'a [T],
     additional_conditions: Option<&str>,
-) -> sqlx::QueryBuilder<'a, Sqlite> {
+) -> sqlx::QueryBuilder<'a, Any> {
     let mut builder = sqlx::QueryBuilder::new(base_query);
 
     if values.is_empty() {

--- a/atoma-state/src/state_manager.rs
+++ b/atoma-state/src/state_manager.rs
@@ -7,19 +7,20 @@ use crate::types::{
 
 use atoma_sui::events::AtomaEvent;
 use flume::Receiver as FlumeReceiver;
+use sqlx::any::install_default_drivers;
 use sqlx::{FromRow, Row};
-use sqlx::{Sqlite, SqlitePool};
+use sqlx::{AnyPool};
 use thiserror::Error;
 use tokio::sync::watch::Receiver;
 
 pub(crate) type Result<T> = std::result::Result<T, AtomaStateManagerError>;
 
-/// AtomaStateManager is a wrapper around a SQLite connection pool, responsible for managing the state of the Atoma system.
+/// AtomaStateManager is a wrapper around a Any connection pool, responsible for managing the state of the Atoma system.
 ///
-/// It provides an interface to interact with the SQLite database, handling operations
+/// It provides an interface to interact with the any database, handling operations
 /// related to tasks, node subscriptions, stacks, and various other system components.
 pub struct AtomaStateManager {
-    /// The SQLite connection pool used for database operations.
+    /// The Any connection pool used for database operations.
     pub state: AtomaState,
     /// Receiver channel from the SuiEventSubscriber
     pub event_subscriber_receiver: FlumeReceiver<AtomaEvent>,
@@ -30,7 +31,7 @@ pub struct AtomaStateManager {
 impl AtomaStateManager {
     /// Constructor
     pub fn new(
-        db: SqlitePool,
+        db: AnyPool,
         event_subscriber_receiver: FlumeReceiver<AtomaEvent>,
         state_manager_receiver: FlumeReceiver<AtomaAtomaStateManagerEvent>,
     ) -> Self {
@@ -43,14 +44,15 @@ impl AtomaStateManager {
 
     /// Creates a new `AtomaStateManager` instance from a database URL.
     ///
-    /// This method establishes a connection to the SQLite database using the provided URL,
+    /// This method establishes a connection to the any database using the provided URL,
     /// creates all necessary tables in the database, and returns a new `AtomaStateManager` instance.
     pub async fn new_from_url(
         database_url: String,
         event_subscriber_receiver: FlumeReceiver<AtomaEvent>,
         state_manager_receiver: FlumeReceiver<AtomaAtomaStateManagerEvent>,
     ) -> Result<Self> {
-        let db = SqlitePool::connect(&database_url).await?;
+        install_default_drivers();
+        let db = AnyPool::connect(&database_url).await?;
         queries::create_all_tables(&db).await?;
         Ok(Self {
             state: AtomaState::new(db),
@@ -161,22 +163,22 @@ impl AtomaStateManager {
     }
 }
 
-/// AtomaState is a wrapper around a SQLite connection pool, responsible for managing the state of the Atoma system.
+/// AtomaState is a wrapper around a any connection pool, responsible for managing the state of the Atoma system.
 #[derive(Clone)]
 pub struct AtomaState {
-    /// The SQLite connection pool used for database operations.
-    pub db: SqlitePool,
+    /// The any connection pool used for database operations.
+    pub db: AnyPool,
 }
 
 impl AtomaState {
     /// Constructor
-    pub fn new(db: SqlitePool) -> Self {
+    pub fn new(db: AnyPool) -> Self {
         Self { db }
     }
 
     /// Creates a new `AtomaState` instance from a database URL.
     pub async fn new_from_url(database_url: String) -> Result<Self> {
-        let db = SqlitePool::connect(&database_url).await?;
+        let db = AnyPool::connect(&database_url).await?;
         queries::create_all_tables(&db).await?;
         Ok(Self { db })
     }
@@ -2096,8 +2098,6 @@ pub enum AtomaStateManagerError {
 }
 
 pub(crate) mod queries {
-    use sqlx::Pool;
-
     use super::*;
 
     /// Generates the SQL query to create the `tasks` table.
@@ -2308,7 +2308,7 @@ pub(crate) mod queries {
     ///
     /// # Arguments
     ///
-    /// * `db` - A reference to the SQLite database pool.
+    /// * `db` - A reference to the Any database pool.
     ///
     /// # Returns
     ///
@@ -2325,15 +2325,15 @@ pub(crate) mod queries {
     /// # Example
     ///
     /// ```rust,ignore
-    /// use sqlx::SqlitePool;
+    /// use sqlx::AnyPool;
     /// use atoma_node::atoma_state::queries;
     ///
-    /// async fn setup_database(pool: &SqlitePool) -> Result<(), Box<dyn std::error::Error>> {
+    /// async fn setup_database(pool: &AnyPool) -> Result<(), Box<dyn std::error::Error>> {
     ///     queries::create_all_tables(pool).await?;
     ///     Ok(())
     /// }
     /// ```
-    pub(crate) async fn create_all_tables(db: &Pool<Sqlite>) -> Result<()> {
+    pub(crate) async fn create_all_tables(db: &AnyPool) -> Result<()> {
         sqlx::query("PRAGMA foreign_keys = ON;").execute(db).await?;
 
         sqlx::query(&create_tasks_table_query()).execute(db).await?;

--- a/atoma-sui/src/subscriber.rs
+++ b/atoma-sui/src/subscriber.rs
@@ -271,7 +271,7 @@ impl SuiEventSubscriber {
 ///
 /// * `event` - A reference to the `AtomaEvent` enum indicating the type of event to handle
 /// * `value` - The serialized event data as a `serde_json::Value`
-/// * `db` - A reference to the SQLite connection pool for database operations
+/// * `db` - A reference to the any connection pool for database operations
 /// * `node_small_ids` - A slice of node IDs that are relevant for the current context
 ///
 /// # Returns
@@ -300,10 +300,10 @@ impl SuiEventSubscriber {
 /// # Examples
 ///
 /// ```ignore
-/// use atoma_state::SqlitePool;
+/// use atoma_state::AnyPool;
 /// use serde_json::Value;
 ///
-/// async fn example(event: AtomaEvent, value: Value, db: &SqlitePool, node_ids: &[u64]) {
+/// async fn example(event: AtomaEvent, value: Value, db: &AnyPool, node_ids: &[u64]) {
 ///     match handle_atoma_event(&event, value, db, node_ids).await {
 ///         Ok(()) => println!("Event handled successfully"),
 ///         Err(e) => eprintln!("Error handling event: {}", e),


### PR DESCRIPTION
Change `sqlite` to `any` so it can be reused in the `atoma-proxy` with postgres.