### PR TITLE
feat: add new_from_config to AtomaSuiClient

### DIFF
--- a/atoma-bin/atoma_daemon.rs
+++ b/atoma-bin/atoma_daemon.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     let state_manager_config =
         AtomaStateManagerConfig::from_file_path(args.config_file_path.clone());
     let client = Arc::new(RwLock::new(
-        AtomaSuiClient::new(args.config_file_path).await?,
+        AtomaSuiClient::new_from_config(args.config_file_path).await?,
     ));
 
     info!(

--- a/atoma-sui/src/client.rs
+++ b/atoma-sui/src/client.rs
@@ -50,8 +50,7 @@ pub struct AtomaSuiClient {
 
 impl AtomaSuiClient {
     /// Constructor
-    pub async fn new<P: AsRef<Path>>(config_path: P) -> Result<Self> {
-        let config = AtomaSuiConfig::from_file_path(config_path);
+    pub async fn new(config: AtomaSuiConfig) -> Result<Self> {
         let sui_config_path = config.sui_config_path();
         let sui_config_path = Path::new(&sui_config_path);
         let mut wallet_ctx = WalletContext::new(
@@ -70,6 +69,31 @@ impl AtomaSuiClient {
             wallet_ctx,
             node_badge,
         })
+    }
+
+    /// Creates a new `AtomaSuiClient` instance from a configuration file.
+    ///
+    /// This method reads the configuration from the specified file path and initializes
+    /// a new `AtomaSuiClient` with the loaded configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `config_path` - A path-like type that represents the location of the configuration file.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self>` - A Result containing the new `AtomaSuiClient` instance if successful,
+    ///   or an error if the configuration couldn't be read.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// * The configuration file cannot be read or parsed.
+    pub async fn new_from_config<P: AsRef<Path>>(
+        config_path: P,
+    ) -> Result<Self> {
+        let config = AtomaSuiConfig::from_file_path(config_path);
+        Self::new(config).await
     }
 
     /// Submits a transaction to register a node in the Atoma network.

--- a/atoma-sui/src/client.rs
+++ b/atoma-sui/src/client.rs
@@ -89,9 +89,7 @@ impl AtomaSuiClient {
     ///
     /// This function will return an error if:
     /// * The configuration file cannot be read or parsed.
-    pub async fn new_from_config<P: AsRef<Path>>(
-        config_path: P,
-    ) -> Result<Self> {
+    pub async fn new_from_config<P: AsRef<Path>>(config_path: P) -> Result<Self> {
         let config = AtomaSuiConfig::from_file_path(config_path);
         Self::new(config).await
     }


### PR DESCRIPTION
Add `new_from_config` to `AtomaSuiClient` and change the new to take config as a parameter. So it's the same as other structs that we have in this repo.