### PR TITLE
feat: add the option to override config from env vars

### DIFF
--- a/atoma-daemon/src/config.rs
+++ b/atoma-daemon/src/config.rs
@@ -38,12 +38,17 @@ impl AtomaDaemonConfig {
     /// * The configuration format doesn't match the expected structure
     pub fn from_file_path<P: AsRef<Path>>(config_file_path: P) -> Self {
         let builder = Config::builder()
-            .add_source(File::with_name(config_file_path.as_ref().to_str().unwrap()));
+            .add_source(File::with_name(config_file_path.as_ref().to_str().unwrap()))
+            .add_source(
+                config::Environment::with_prefix("ATOMA_DAEMON")
+                    .keep_prefix(true)
+                    .separator("__"),
+            );
         let config = builder
             .build()
             .expect("Failed to generate atoma-daemon configuration file");
         config
-            .get::<Self>("atoma-daemon")
+            .get::<Self>("atoma_daemon")
             .expect("Failed to generate configuration instance")
     }
 }

--- a/atoma-service/src/config.rs
+++ b/atoma-service/src/config.rs
@@ -66,12 +66,17 @@ impl AtomaServiceConfig {
     /// * The configuration format doesn't match the expected structure
     pub fn from_file_path<P: AsRef<Path>>(config_file_path: P) -> Self {
         let builder = Config::builder()
-            .add_source(File::with_name(config_file_path.as_ref().to_str().unwrap()));
+            .add_source(File::with_name(config_file_path.as_ref().to_str().unwrap()))
+            .add_source(
+                config::Environment::with_prefix("ATOMA_SERVICE")
+                    .keep_prefix(true)
+                    .separator("__"),
+            );
         let config = builder
             .build()
             .expect("Failed to generate atoma-service configuration file");
         config
-            .get::<Self>("atoma-service")
+            .get::<Self>("atoma_service")
             .expect("Failed to generate configuration instance")
     }
 }

--- a/atoma-state/src/config.rs
+++ b/atoma-state/src/config.rs
@@ -41,14 +41,21 @@ impl AtomaStateManagerConfig {
     /// let config = AtomaStateManagerConfig::from_file_path("path/to/config.toml");
     /// ```
     pub fn from_file_path<P: AsRef<Path>>(config_file_path: P) -> Self {
-        let builder = Config::builder().add_source(config::File::with_name(
-            config_file_path.as_ref().to_str().unwrap(),
-        ));
+        let builder = Config::builder()
+            .add_source(config::File::with_name(
+                config_file_path.as_ref().to_str().unwrap(),
+            ))
+            .add_source(
+                config::Environment::with_prefix("ATOMA_STATE")
+                    .keep_prefix(true)
+                    .separator("__"),
+            );
+
         let config = builder
             .build()
             .expect("Failed to generate atoma state configuration file");
         config
-            .get::<Self>("atoma-state")
+            .get::<Self>("atoma_state")
             .expect("Failed to generate configuration instance")
     }
 }

--- a/atoma-sui/src/config.rs
+++ b/atoma-sui/src/config.rs
@@ -177,14 +177,21 @@ impl AtomaSuiConfig {
     /// let config = AtomaSuiConfig::from_file_path("config.toml");
     /// ```
     pub fn from_file_path<P: AsRef<Path>>(config_file_path: P) -> Self {
-        let builder = Config::builder().add_source(config::File::with_name(
-            config_file_path.as_ref().to_str().unwrap(),
-        ));
+        let builder = Config::builder()
+            .add_source(config::File::with_name(
+                config_file_path.as_ref().to_str().unwrap(),
+            ))
+            .add_source(
+                config::Environment::with_prefix("ATOMA_SUI")
+                    .keep_prefix(true)
+                    .separator("__"),
+            );
+
         let config = builder
             .build()
             .expect("Failed to generate atoma-sui configuration file");
         config
-            .get::<Self>("atoma-sui")
+            .get::<Self>("atoma_sui")
             .expect("Failed to generate configuration instance")
     }
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,10 +1,10 @@
-[atoma-service]
+[atoma_service]
 inference_service_url = "http://vllm:8000" # URL of the VLLM inference service, that is compatible with the the docker-compose file specs
 models = ["meta-llama/Llama-3.1-70B-Instruct"]
 revisions = ["main"]
 service_bind_address = "0.0.0.0:3000"
 
-[atoma-sui]
+[atoma_sui]
 http_rpc_node_addr = "https://fullnode.testnet.sui.io:443" # Current RPC node address for testnet
 atoma_db = "0x7b8f40e38698deb650519a51f9c1a725bf8cfdc074d1552a4dc85976c2b414be" # Current ATOMA DB object ID for testnet
 atoma_package_id = "0xc05bae323433740c969d8cf938c48d7559490be5f8dde158792e7a0623787013" # Current ATOMA package ID for testnet
@@ -17,10 +17,10 @@ sui_config_path = "/root/.sui/sui_config/client.yaml" # Path to the Sui client c
 sui_keystore_path = "/root/.sui/sui_config/sui.keystore" # Path to the Sui keystore file, accessed from the docker container (if this is not the case, pass in the full path, on your host machine which is by default ~/.sui/sui_config/sui.keystore)
 cursor_path = "./cursor.toml" # Path to the Sui events cursor file
 
-[atoma-state]
+[atoma_state]
 database_url = "sqlite:///app/data/atoma.db"  # Path inside the container
 
-[atoma-daemon]
+[atoma_daemon]
 service_bind_address = "0.0.0.0:3001"
 node_badges = [
     ["0x268e6af9502dcdcaf514bb699c880b37fa1e8d339293bc4f331f2dde54180600", 1]


### PR DESCRIPTION
Add the possibility to override config values from env vars.
E.g.  in the config
```
[atoma_daemon]
service_bind_address
```
can be overwritten with setting `ATOMA_DAEMON__SERVICE_BIND_ADDRESS` (mind the double _ between ATOMA_DAEMON and the rest.
After merging this, change your local config.toml. The section names are changing from dash to underscore, e.g. `atoma-daemon` to `atoma_daemon`