### PR TITLE
fix: missing timestamp

### DIFF
--- a/atoma-sui/src/subscriber.rs
+++ b/atoma-sui/src/subscriber.rs
@@ -582,9 +582,10 @@ async fn parse_event(
         AtomaEventIdentifier::FirstSubmissionEvent => Ok(AtomaEvent::FirstSubmissionEvent(
             serde_json::from_value(value)?,
         )),
-        AtomaEventIdentifier::StackCreatedEvent => Ok(AtomaEvent::StackCreatedEvent(
+        AtomaEventIdentifier::StackCreatedEvent => Ok(AtomaEvent::StackCreatedEvent((
             serde_json::from_value(value)?,
-        )),
+            timestamp_ms,
+        ))),
         AtomaEventIdentifier::StackTrySettleEvent => Ok(AtomaEvent::StackTrySettleEvent((
             serde_json::from_value(value)?,
             timestamp_ms,


### PR DESCRIPTION
Add the missing timestamp to stack created event.