### PR TITLE
ci: add e2e test job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,35 @@
+name: End-to-end testing
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-atoma-e2e-tests:
+    name: Run Atoma e2e tests
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ fromJSON(github.repository == 'atoma-network/atoma-node' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
+    strategy:
+      matrix:
+        flavour: [chromium, native]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.flavour }} image
+        run: ./scripts/build-e2e-image.sh
+        env:
+          AWS_BUCKET_NAME: ${{ vars.S3_ATOMA_BUILD_CACHE_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ vars.S3_ATOMA_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_ATOMA_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.S3_ATOMA_BUILD_CACHE_AWS_REGION }}
+          FLAVOUR: ${{ matrix.flavour }}
+
+      - name: Run ${{ matrix.flavour }} tests
+        uses: atoma-network/atoma-testground/.github/actions/run-chat-completion-request@master

--- a/scripts/build-e2e-image.sh
+++ b/scripts/build-e2e-image.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This uses the same S3 cache as all test-plans images. Because we use `cargo-chef` in the Dockerfile, we have a layer available with all dependencies built.
+
+CACHE_TO=""
+
+# If we have credentials, write to cache
+if [[ -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
+  CACHE_TO="--cache-to   type=s3,mode=max,bucket=${AWS_BUCKET_NAME},region=${AWS_REGION},prefix=buildCache,name=${FLAVOUR}-atoma-node-head"
+fi
+
+docker buildx build \
+  --load \
+  $CACHE_TO \
+  --cache-from type=s3,mode=max,bucket=${AWS_BUCKET_NAME},region=${AWS_REGION},prefix=buildCache,name=${FLAVOUR}-atoma-node-head \
+  -t ${FLAVOUR}-atoma-node-head \
+  . \
+  -f e2e-tests/Dockerfile.${FLAVOUR}


### PR DESCRIPTION
This relates to the broader effort in https://github.com/atoma-network/atoma-testground

This will run an e2e test using the dev environment that will simulate a chat completion request.