### PR TITLE
build: fix issue related to rustls audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,8 +3564,7 @@ dependencies = [
 [[package]]
 name = "hyper-rustls"
 version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+source = "git+https://github.com/rustls/hyper-rustls?branch=main#426c0a7091b8ca4a938440fdb527c5a37e53a5ab"
 dependencies = [
  "futures-util",
  "http 1.2.0",
@@ -8684,8 +8683,7 @@ dependencies = [
 [[package]]
 name = "tokio-rustls"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+source = "git+https://github.com/rustls/tokio-rustls?branch=main#cd399aba544e01f08047b40a6988365c195d6076"
 dependencies = [
  "rustls 0.23.21",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 
 members = [
     "atoma-confidential",
-    "atoma-daemon", 
+    "atoma-daemon",
     "atoma-service",
     "atoma-state",
     "atoma-sui",
@@ -71,3 +71,7 @@ utoipa = "5.1.1"
 utoipa-swagger-ui = "8.0.1"
 validator = "0.20.0"
 x25519-dalek = "2.0.1"
+
+[patch.crates-io]
+hyper-rustls = { git = "https://github.com/rustls/hyper-rustls", branch = "main" }
+tokio-rustls = { git = "https://github.com/rustls/tokio-rustls", branch = "main" }


### PR DESCRIPTION
Our security audit detected [a vulnerability](https://github.com/atoma-network/atoma-node/actions/runs/12998894498/job/36253012065) in `rustls` which is a transitive dependency. 

This applies a patch for it.

The other current [RSA timing vulnerability](https://rustsec.org/advisories/RUSTSEC-2023-0071.html)  is currently unpatched but doesn't apply to us.