### PR TITLE
fix: add p2p config fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1717,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -4628,10 +4653,12 @@ dependencies = [
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
+ "libp2p-noise",
  "libp2p-quic",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
+ "libp2p-yamux",
  "multiaddr 0.18.2",
  "pin-project",
  "rw-stream-sink",
@@ -4837,6 +4864,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-noise"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcc133e0f3cea07acde6eb8a9665cb11b600bd61110b010593a0210b8153b16"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "multiaddr 0.18.2",
+ "multihash 0.19.3",
+ "once_cell",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "snow",
+ "static_assertions",
+ "thiserror 2.0.11",
+ "tracing",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "libp2p-quic"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4941,6 +4992,21 @@ dependencies = [
  "libp2p-swarm",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+dependencies = [
+ "either",
+ "futures",
+ "libp2p-core",
+ "thiserror 2.0.11",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.4",
 ]
 
 [[package]]
@@ -5828,6 +5894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6673,6 +6745,17 @@ dependencies = [
  "rustix",
  "tracing",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -8434,6 +8517,23 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "ring 0.17.8",
+ "rustc_version 0.4.1",
+ "sha2 0.10.8",
+ "subtle",
+]
 
 [[package]]
 name = "socket2"
@@ -11100,6 +11200,37 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.8.4",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.5",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/atoma-p2p/Cargo.toml
+++ b/atoma-p2p/Cargo.toml
@@ -10,7 +10,19 @@ ciborium = { workspace = true }
 chrono = { workspace = true }
 config = { workspace = true }
 isocountry = { workspace = true }
-libp2p = { workspace = true, features = [ "tokio", "identify", "gossipsub", "mdns", "kad", "macros","quic"] }
+libp2p = { workspace = true, features = [
+	"tokio",
+	"dns",
+	"identify",
+	"gossipsub",
+	"mdns",
+	"kad",
+	"macros",
+	"quic",
+	"tcp",
+	"yamux",
+	"noise",
+] }
 fastcrypto = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }

--- a/atoma-p2p/src/config.rs
+++ b/atoma-p2p/src/config.rs
@@ -27,10 +27,10 @@ pub struct AtomaP2pNodeConfig {
     /// will be terminated to free up resources.
     pub idle_connection_timeout: Duration,
 
-    /// The address to listen on for incoming tcp connections.
+    /// The address to listen on for incoming QUIC connections.
     ///
     /// This is the address that the node will use to listen for incoming connections.
-    /// It is a string in the format of "/ip4/x.x.x.x/tcp/x".
+    /// It is a string in the format of "/ip4/x.x.x.x/udp/x/quic-v1".
     pub listen_addr: String,
 
     /// The public URL of the node.
@@ -46,7 +46,7 @@ pub struct AtomaP2pNodeConfig {
     /// The list of bootstrap nodes to connect to.
     ///
     /// Bootstrap nodes are nodes that the node will use to bootstrap its network connection.
-    /// They are a list of strings in the format of "/ip4/x.x.x.x/tcp/x".
+    /// They are a list of strings in the format of "/ip4/x.x.x.x/udp/x/quic-v1/p2p/QmHash...".
     pub bootstrap_nodes: Vec<String>,
 }
 

--- a/atoma-p2p/src/service.rs
+++ b/atoma-p2p/src/service.rs
@@ -3,13 +3,14 @@ use crate::{
     timer::{usage_metrics_timer_task, NodeUsageMetrics},
     types::{AtomaP2pEvent, GossipMessage, UsageMetrics},
 };
+use config::ConfigError;
 use flume::Sender;
 use futures::StreamExt;
 use libp2p::{
     gossipsub::{self, ConfigBuilderError},
-    identify, kad, mdns,
+    identify, kad, mdns, noise,
     swarm::{DialError, NetworkBehaviour, SwarmEvent},
-    Multiaddr, PeerId, Swarm, SwarmBuilder, TransportError,
+    tcp, yamux, PeerId, Swarm, SwarmBuilder, TransportError,
 };
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
@@ -134,13 +135,13 @@ impl AtomaP2pNode {
     ///     let config = AtomaP2pNodeConfig {
     ///         heartbeat_interval: std::time::Duration::from_secs(1),
     ///         idle_connection_timeout: std::time::Duration::from_secs(30),
-    ///         listen_addr: "/ip4/127.0.0.1/tcp/8080".to_string(),
+    ///         listen_addr: "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/QmHash...".to_string(),
     ///         seed_nodes: vec![],
     ///         public_url: "node1.example.com".to_string(),
     ///         node_small_id: 1,
     ///     };
     ///     let keystore = Arc::new(FileBasedKeystore::new(&std::path::PathBuf::from("keys"))?);
-    ///     
+    ///
     ///     AtomaP2pNode::start(config, keystore, state_manager_sender, false)
     /// }
     /// ```
@@ -168,6 +169,11 @@ impl AtomaP2pNode {
     ) -> Result<Self, AtomaP2pNodeError> {
         let mut swarm = SwarmBuilder::with_new_identity()
             .with_tokio()
+            .with_tcp(
+                tcp::Config::default(),
+                noise::Config::new,
+                yamux::Config::default,
+            )?
             .with_quic()
             .with_behaviour(|key| {
                 // To content-address message, we can take the hash of message and use it as an ID.
@@ -244,34 +250,30 @@ impl AtomaP2pNode {
                 );
                 AtomaP2pNodeError::GossipsubSubscriptionError(e)
             })?;
-        swarm.listen_on(config.listen_addr.parse()?).map_err(|e| {
-            error!(
-                target = "atoma-p2p",
-                event = "listen_on_error",
-                listen_addr = config.listen_addr,
-                error = %e,
-                "Failed to listen on address"
-            );
-            AtomaP2pNodeError::SwarmListenOnError(e)
-        })?;
+        swarm
+            .listen_on(config.listen_addr.parse().unwrap())
+            .map_err(|e| {
+                error!(
+                    target = "atoma-p2p",
+                    event = "listen_on_error",
+                    listen_addr = config.listen_addr,
+                    error = %e,
+                    "Failed to listen on address"
+                );
+                AtomaP2pNodeError::SwarmListenOnError(e)
+            })?;
 
-        for bootstrap_node_addr in config.bootstrap_nodes {
-            match bootstrap_node_addr.parse::<Multiaddr>() {
-                Ok(addr) => {
-                    swarm.dial(addr).map_err(|e| {
-                        error!(
-                            target = "atoma-p2p",
-                            event = "dial_bootstrap_node",
-                            bootstrap_node = bootstrap_node_addr,
-                            error = %e,
-                            "Failed to dial bootstrap node"
-                        );
-                        AtomaP2pNodeError::BootstrapNodeDialError(e)
-                    })?;
+        for peer_id in config.bootstrap_nodes {
+            match peer_id.parse::<PeerId>() {
+                Ok(peer_id) => {
+                    swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .add_address(&peer_id, "/dnsaddr/bootstrap.libp2p.io".parse()?);
                     debug!(
                         target = "atoma-p2p",
                         event = "dialed_bootstrap_node",
-                        bootstrap_node = bootstrap_node_addr,
+                        peer_id = %peer_id,
                         "Dialed bootstrap node"
                     );
                 }
@@ -279,7 +281,7 @@ impl AtomaP2pNode {
                     error!(
                         target = "atoma-p2p",
                         event = "bootstrap_node_parse_error",
-                        bootstrap_node = bootstrap_node_addr,
+                        peer_id = %peer_id,
                         error = %e,
                         "Failed to parse bootstrap node address"
                     );
@@ -348,13 +350,13 @@ impl AtomaP2pNode {
     ///
     /// async fn run_node(node: AtomaP2pNode) {
     ///     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    ///     
+    ///
     ///     // Run the node in the background
     ///     let node_handle = tokio::spawn(node.run(shutdown_rx));
-    ///     
+    ///
     ///     // Signal shutdown when needed
     ///     shutdown_tx.send(true).expect("Failed to send shutdown signal");
-    ///     
+    ///
     ///     // Wait for the node to shut down
     ///     node_handle.await.expect("Node failed to shut down cleanly");
     /// }
@@ -886,6 +888,10 @@ pub enum AtomaP2pNodeError {
     InvalidPublicAddressError(String),
     #[error("Failed to parse listen address: {0}")]
     ListenAddressParseError(#[from] libp2p::multiaddr::Error),
+    #[error("Failed to build TCP config: {0}")]
+    TcpConfigBuildError(#[from] ConfigError),
+    #[error("Failed to initialize noise encryption: {0}")]
+    NoiseError(#[from] libp2p::noise::Error),
     #[error("Failed to send event to state manager: {0}")]
     StateManagerError(#[from] flume::SendError<StateManagerEvent>),
     #[error("Failed to sign hashed message, with error: {0}")]

--- a/config.example.toml
+++ b/config.example.toml
@@ -41,19 +41,19 @@ node_badges = [
 heartbeat_interval = { secs = 30, nanos = 0 }
 # Maximum duration a connection can remain idle before closing (in seconds)
 idle_connection_timeout = { secs = 60, nanos = 0 }
-# Address to listen for incoming TCP connections (format: "/ip4/x.x.x.x/tcp/x")
-listen_addr = "/ip4/0.0.0.0/tcp/4001"
+# Address to listen for incoming QUIC connections (format: "/ip4/x.x.x.x/udp/x")
+listen_addr = "/ip4/0.0.0.0/udp/4001/quic-v1"
 # Node's small ID (assigned by Atoma smart contract)
 node_small_id = 1
 # The HTTP(s) public URL of the node
 public_url = "https://<PUBLIC_URL>"
 # List of bootstrap nodes to connect to
 bootstrap_nodes = [
-    "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",  
-    "QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",  
-    "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",  
-    "QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",  
-    "12D3KooWKnDdG3iXw9eTFijk3EWSunZcFi54Zka4wmtqtt6rPxc",  
+    "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+    "QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
+    "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+    "QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
+    "12D3KooWKnDdG3iXw9eTFijk3EWSunZcFi54Zka4wmtqtt6rPxc",
 ]
 # required, replace this with the country (ISO 3166-1 alpha-2) of the node (https://www.iso.org/obp/ui/#search/code/
 country = ""


### PR DESCRIPTION
We were having issues listening on the config address as it was a TCP configered address.

I've also added the TCP behaviour as this will be useful in Kademlia for connecting to peers which may not be QUIC-enabled