### PR TITLE
build: allow for `linux/amd64` profiles on docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Additionally, we offer the flexibility to run Atoma's node in two different mode
 
 To run the Atoma node in a confidential mode, you need to pass the `confidential` profile to the `docker compose up` command:
 
+Also please note that if you are on an ARM64 architecture, you need to set the `PLATFORM=linux/arm64` environment variable and then run the `docker compose up` command.
+
 ```bash
 # Build and start all services
 COMPOSE_PROFILES=chat_completions_vllm,embeddings_tei,image_generations_mistralrs,confidential docker compose up --build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ x-atoma-node-confidential: &atoma-node-confidential
 
 x-atoma-node-non-confidential: &atoma-node-non-confidential
   image: ghcr.io/atoma-network/atoma-node:default
+  platform: linux/amd64
   volumes:
     - ${CONFIG_PATH:-./config.toml}:/app/config.toml
     - ./logs:/app/logs
@@ -81,6 +82,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v3.1.0
+    platform: linux/amd64
     restart: always
     ports:
       - "${PROMETHEUS_PORT:-9090}:9090"
@@ -281,9 +283,8 @@ services:
     <<: *inference-service-cpu
     container_name: chat-completions
     profiles: [chat_completions_mistralrs_cpu]
-    build:
-      context: https://github.com/EricLBuehler/mistral.rs.git#v0.4.0
-      dockerfile: Dockerfile
+    image: ghcr.io/ericlbuehler/mistral.rs:cpu-0.4
+    platform: linux/amd64
     command: plain -m ${CHAT_COMPLETIONS_MODEL}
 
   tei:
@@ -297,7 +298,8 @@ services:
     <<: *inference-service-cuda
     container_name: image-generations
     profiles: [image_generations_mistralrs]
-    image: ${MISTRALRS_IMAGE}
+    image: ghcr.io/ericlbuehler/mistral.rs:cpu-0.4
+    platform: linux/amd64
     command: diffusion-plain -m ${IMAGE_GENERATIONS_MODEL} --arch ${IMAGE_GENERATIONS_ARCHITECTURE}
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -94,6 +94,11 @@ services:
     env_file: .env
     networks:
       - atoma-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   grafana:
     image: grafana/grafana:11.5.1
@@ -170,11 +175,6 @@ services:
       tempo:
         condition: service_healthy
         required: true
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:13133"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   atoma-node-confidential:
     <<: *atoma-node-confidential
@@ -206,7 +206,7 @@ services:
         condition: service_started
         required: false
       otel-collector:
-        condition: service_healthy
+        condition: service_started
         required: true
 
   atoma-node-non-confidential:
@@ -237,8 +237,9 @@ services:
         required: false
       mistralrs:
         condition: service_started
+        required: false
       otel-collector:
-        condition: service_healthy
+        condition: service_started
         required: true
 
   vllm:
@@ -281,7 +282,7 @@ services:
     container_name: chat-completions
     profiles: [chat_completions_mistralrs_cpu]
     build:
-      context: https://github.com/EricLBuehler/mistral.rs.git
+      context: https://github.com/EricLBuehler/mistral.rs.git#v0.4.0
       dockerfile: Dockerfile
     command: plain -m ${CHAT_COMPLETIONS_MODEL}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Atoma services
 x-atoma-node-confidential: &atoma-node-confidential
   image: ghcr.io/atoma-network/atoma-node:latest
+  platform: ${PLATFORM:-} # Will be empty if not set
   volumes:
     - ${CONFIG_PATH:-./config.toml}:/app/config.toml
     - ./logs:/app/logs
@@ -13,7 +14,7 @@ x-atoma-node-confidential: &atoma-node-confidential
 
 x-atoma-node-non-confidential: &atoma-node-non-confidential
   image: ghcr.io/atoma-network/atoma-node:default
-  platform: linux/amd64
+  platform: ${PLATFORM:-} # Will be empty if not set
   volumes:
     - ${CONFIG_PATH:-./config.toml}:/app/config.toml
     - ./logs:/app/logs
@@ -62,6 +63,7 @@ x-inference-service-rocm: &inference-service-rocm
 services:
   postgres-db:
     image: postgres:13
+    platform: ${PLATFORM:-} # Will be empty if not set
     restart: always
     environment:
       - POSTGRES_DB=${POSTGRES_DB}
@@ -82,7 +84,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v3.1.0
-    platform: linux/amd64
+    platform: ${PLATFORM:-}
     restart: always
     ports:
       - "${PROMETHEUS_PORT:-9090}:9090"
@@ -104,6 +106,7 @@ services:
 
   grafana:
     image: grafana/grafana:11.5.1
+    platform: ${PLATFORM:-}
     restart: always
     ports:
       - "${GRAFANA_PORT:-30001}:3000"
@@ -122,6 +125,7 @@ services:
 
   loki:
     image: grafana/loki:2.9.4
+    platform: ${PLATFORM:-}
     ports:
       - "3100:3100"
     volumes:
@@ -138,6 +142,7 @@ services:
 
   tempo:
     image: grafana/tempo:2.7.0
+    platform: ${PLATFORM:-}
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
@@ -155,6 +160,7 @@ services:
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.119.0
+    platform: ${PLATFORM:-}
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -298,8 +304,8 @@ services:
     <<: *inference-service-cuda
     container_name: image-generations
     profiles: [image_generations_mistralrs]
-    image: ghcr.io/ericlbuehler/mistral.rs:cpu-0.4
-    platform: linux/amd64
+    image: ${MISTRALRS_IMAGE}
+    platform: ${PLATFORM:-}
     command: diffusion-plain -m ${IMAGE_GENERATIONS_MODEL} --arch ${IMAGE_GENERATIONS_ARCHITECTURE}
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -303,6 +303,7 @@ services:
 networks:
   atoma-network:
     driver: bridge
+    name: atoma-network
 
 volumes:
   postgres-data:


### PR DESCRIPTION
A user can now run 

```console
	export PLATFORM=linux/amd64
```

Then 

```console
COMPOSE_PROFILES=mistralrs-cpu,non-confidential docker compose up -d
```

This builds off the fixes in https://github.com/atoma-network/atoma-node/pull/409