### PR TITLE
build: add internal port for CI runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ POSTGRES_DB=atoma
 POSTGRES_USER=atoma
 POSTGRES_PASSWORD=
 POSTGRES_PORT=5432
-
+## This is the port used in CI runs as Github Actions does not support exposing ports
+POSTGRES_INTERNAL_PORT=5432
 # Sui Configuration
 SUI_CONFIG_PATH=~/.sui/sui_config
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -53,12 +53,12 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${POSTGRES_PORT}:${POSTGRES_INTERNAL_PORT}"
     env_file: .env
     networks:
       - atoma-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -p 5432 || exit 1"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -p ${POSTGRES_INTERNAL_PORT} || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This is needed for https://github.com/atoma-network/atoma-testground