### PR TITLE
feat: add p2p tester crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "atoma-daemon",
  "atoma-p2p",
  "atoma-sui",
+ "atoma-utils",
  "clap 4.5.31",
  "config",
  "flume",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1_der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+
+[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4871,12 +4877,14 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 dependencies = [
+ "asn1_der",
  "bs58 0.5.1",
  "ed25519-dalek",
  "hkdf",
  "multihash 0.19.3",
  "quick-protobuf",
  "rand 0.8.5",
+ "ring 0.17.11",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoma-p2p-tester"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atoma-daemon",
+ "atoma-p2p",
+ "atoma-sui",
+ "clap 4.5.31",
+ "config",
+ "flume",
+ "serde",
+ "serde_json",
+ "sui-keys",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "atoma-service"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "atoma-state",
     "atoma-sui",
     "atoma-utils",
+    "atoma-p2p-tester",
 ]
 
 [workspace.package]

--- a/atoma-bin/atoma_daemon.rs
+++ b/atoma-bin/atoma_daemon.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use atoma_daemon::{
     config::AtomaDaemonConfig,
     server::{run_server, DaemonState},
+    telemetry,
 };
 use atoma_state::{config::AtomaStateManagerConfig, AtomaState};
 use atoma_sui::client::Client;
@@ -16,8 +17,6 @@ use tokio::{
     try_join,
 };
 use tracing::info;
-
-mod telemetry;
 
 #[derive(Parser)]
 struct DaemonArgs {

--- a/atoma-bin/atoma_node.rs
+++ b/atoma-bin/atoma_node.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::{Context, Result};
 use atoma_confidential::AtomaConfidentialCompute;
-use atoma_daemon::{AtomaDaemonConfig, DaemonState};
+use atoma_daemon::{telemetry, AtomaDaemonConfig, DaemonState};
 use atoma_p2p::{AtomaP2pNode, AtomaP2pNodeConfig};
 use atoma_service::{config::AtomaServiceConfig, server::AppState};
 use atoma_state::{config::AtomaStateManagerConfig, AtomaState, AtomaStateManager};
@@ -20,8 +20,6 @@ use tokio::{
     try_join,
 };
 use tracing::{error, info, instrument, warn};
-
-mod telemetry;
 
 /// The name of the environment variable for the Hugging Face token
 const HF_TOKEN: &str = "HF_TOKEN";

--- a/atoma-daemon/src/lib.rs
+++ b/atoma-daemon/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod components;
 pub mod config;
 pub(crate) mod handlers;
 pub mod server;
+pub mod telemetry;
 pub mod types;
 
 pub use crate::{config::AtomaDaemonConfig, server::DaemonState};

--- a/atoma-daemon/src/telemetry.rs
+++ b/atoma-daemon/src/telemetry.rs
@@ -80,6 +80,13 @@ fn init_traces(otlp_endpoint: &str) -> Result<sdktrace::Tracer> {
 }
 
 /// Configure logging with JSON formatting, file output, and console output
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Failed to create logs directory
+/// - Failed to initialize OpenTelemetry tracing
+/// - Failed to set global default subscriber
 pub fn setup_logging() -> Result<(WorkerGuard, WorkerGuard)> {
     let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
         .unwrap_or_else(|_| DEFAULT_OTLP_ENDPOINT.to_string());

--- a/atoma-p2p-tester/.gitignore
+++ b/atoma-p2p-tester/.gitignore
@@ -1,0 +1,2 @@
+config.toml
+.env

--- a/atoma-p2p-tester/Cargo.toml
+++ b/atoma-p2p-tester/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "atoma-p2p-tester"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+atoma-p2p = { path = "../atoma-p2p" }
+atoma-sui = { path = "../atoma-sui" }
+atoma-daemon = { path = "../atoma-daemon" }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+config = { workspace = true }
+sui-keys = { workspace = true }
+flume = { workspace = true }

--- a/atoma-p2p-tester/Cargo.toml
+++ b/atoma-p2p-tester/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 atoma-p2p = { path = "../atoma-p2p" }
 atoma-sui = { path = "../atoma-sui" }
 atoma-daemon = { path = "../atoma-daemon" }
+atoma-utils = { path = "../atoma-utils" }
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/atoma-p2p-tester/Dockerfile
+++ b/atoma-p2p-tester/Dockerfile
@@ -1,0 +1,68 @@
+# Builder stage
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS builder
+
+# Add platform-specific arguments
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETARCH
+
+# Trace level argument
+ARG TRACE_LEVEL
+ARG PROFILE
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+	build-essential \
+	pkg-config \
+	curl \
+	libssl-dev \
+	libssl3 \
+	ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Install Rust 1.84.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.84.0 \
+	&& . "$HOME/.cargo/env"
+
+# Add cargo to PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Set working directory to the workspace root
+WORKDIR /usr/src/atoma-node
+
+# Note: This Dockerfile should be built from the workspace root
+# with: docker build -f atoma-p2p-tester/Dockerfile -t atoma-p2p-tester .
+COPY . .
+
+# Compile atoma-p2p-tester
+RUN cargo build --release --package atoma-p2p-tester
+
+# Final stage
+FROM ubuntu:24.04
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+	ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Create necessary directories
+RUN mkdir -p /app/logs
+
+# Copy the built binary from builder stage
+COPY --from=builder /usr/src/atoma-node/target/release/atoma-p2p-tester /usr/local/bin/atoma-p2p-tester
+
+# Set executable permissions explicitly
+RUN chmod +x /usr/local/bin/atoma-p2p-tester
+
+# Copy entrypoint script from the workspace root
+COPY --from=builder /usr/src/atoma-node/entrypoint.sh /usr/local/bin/
+
+# Set executable permissions
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/usr/local/bin/atoma-p2p-tester", "--config-path", "/app/config.toml"]

--- a/atoma-p2p-tester/docker-compose.yml
+++ b/atoma-p2p-tester/docker-compose.yml
@@ -1,0 +1,155 @@
+# Base configurations that are common between environments
+x-atoma-p2p-base: &atoma-p2p-base
+  build: &atoma-p2p-base-build
+    context: .
+    dockerfile: Dockerfile
+    args: &atoma-p2p-base-build-args
+      TRACE_LEVEL: ${TRACE_LEVEL:-info}
+  volumes:
+    - ${CONFIG_PATH:-./config.toml}:/app/config.toml
+    - ./logs:/app/logs
+    - sui-config-volume:/root/.sui/sui_config
+    - ${SUI_CONFIG_PATH:-~/.sui/sui_config}:/tmp/.sui/sui_config
+  env_file:
+    - .env
+  environment:
+    - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+  depends_on:
+    prometheus:
+      condition: service_healthy
+    grafana:
+      condition: service_healthy
+    loki:
+      condition: service_healthy
+    tempo:
+      condition: service_healthy
+  networks:
+    - atoma-network
+
+services:
+  atoma-p2p-tester-local:
+    profiles: ["local"]
+    <<: *atoma-p2p-base
+    image: ghcr.io/atoma-network/atoma-p2p-tester:local-latest
+    build:
+      <<: *atoma-p2p-base-build
+      args:
+        <<: *atoma-p2p-base-build-args
+        PROFILE: local
+    ports:
+      - "${ATOMA_P2P_TESTER_SERVICE_PORT:-8080}:8080"
+
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    platform: ${PLATFORM:-}
+    restart: always
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    env_file: .env
+    networks:
+      - atoma-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:11.5.1
+    platform: ${PLATFORM:-}
+    restart: always
+    ports:
+      - "${GRAFANA_PORT:-30001}:3000"
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana_data:/var/lib/grafana
+    env_file: .env
+    environment:
+      - GF_SERVER_ROOT_URL=http://${GRAFANA_DOMAIN}:${GRAFANA_PORT:-30001}/
+    networks:
+      - atoma-network
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  loki:
+    image: grafana/loki:2.9.4
+    platform: ${PLATFORM:-}
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki.yaml:/etc/loki/loki.yaml
+      - loki-data:/loki
+    command: -config.file=/etc/loki/loki.yaml
+    networks:
+      - atoma-network
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  tempo:
+    image: grafana/tempo:2.7.0
+    platform: ${PLATFORM:-}
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - tempo-data:/tmp/tempo
+    ports:
+      - "3200:3200"
+    networks:
+      - atoma-network
+    user: "0"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3200/status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.119.0
+    platform: ${PLATFORM:-}
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+      - "8889:8889" # Prometheus exporter
+    networks:
+      - atoma-network
+    depends_on:
+      prometheus:
+        condition: service_healthy
+        required: true
+      grafana:
+        condition: service_healthy
+        required: true
+      loki:
+        condition: service_healthy
+        required: true
+      tempo:
+        condition: service_healthy
+        required: true
+
+volumes:
+  sui-config-volume:
+  grafana_data:
+  prometheus-data:
+  loki-data:
+  tempo-data:
+
+networks:
+  atoma-network:
+    driver: bridge

--- a/atoma-p2p-tester/src/main.rs
+++ b/atoma-p2p-tester/src/main.rs
@@ -2,11 +2,13 @@ use anyhow::{Context, Result};
 use atoma_daemon::telemetry;
 use atoma_p2p::{config::AtomaP2pNodeConfig, service::AtomaP2pNode, types::AtomaP2pEvent};
 use atoma_sui::config::Config as AtomaSuiConfig;
+use atoma_utils::spawn_with_shutdown;
 use clap::Parser;
 use std::time::Duration;
 use std::{path::PathBuf, sync::Arc};
 use sui_keys::keystore::FileBasedKeystore;
 use tokio::signal;
+use tokio::sync::watch;
 use tracing::{error, info};
 
 #[derive(Parser, Debug)]
@@ -23,7 +25,6 @@ struct Args {
 
 struct Config {
     sui: AtomaSuiConfig,
-
     p2p: AtomaP2pNodeConfig,
 }
 
@@ -39,6 +40,8 @@ impl Config {
 }
 
 #[tokio::main]
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::redundant_pub_crate)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Store both guards to keep logging active for the duration of the program
     let (_file_guard, _stdout_guard) =
@@ -54,51 +57,105 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a channel to receive events from the P2P node
     let (atoma_p2p_sender, atoma_p2p_receiver) = flume::unbounded();
+    let (shutdown_sender, shutdown_receiver) = watch::channel(false);
 
     // Create and start the P2P node
     let keystore: FileBasedKeystore =
-        FileBasedKeystore::new(&PathBuf::from(&config.sui.sui_keystore_path()))?;
+        FileBasedKeystore::new(&PathBuf::from(&config.sui.sui_keystore_path()))
+            .context("Failed to create keystore")?;
 
-    let _node = AtomaP2pNode::start(config.p2p, Arc::new(keystore), atoma_p2p_sender, false)?;
+    let node = AtomaP2pNode::start(config.p2p, Arc::new(keystore), atoma_p2p_sender, false)
+        .context("Failed to start P2P node")?;
+
+    let atoma_p2p_node_handle =
+        spawn_with_shutdown(node.run(shutdown_receiver.clone()), shutdown_sender.clone());
+
+    // Add a periodic heartbeat/metrics reporting task
+    let heartbeat_task = {
+        let shutdown_rx = shutdown_receiver.clone();
+        let node_id = args.node_id;
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            let mut shutdown_rx = shutdown_rx;
+            let mut tick_count = 0;
+
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        tick_count += 1;
+                        info!(
+                            target = "atoma-p2p-tester",
+                            event = "heartbeat",
+                            node_id = node_id,
+                            uptime_seconds = interval.period().as_secs() * tick_count,
+                            "P2P tester node is healthy"
+                        );
+                    }
+                    Ok(()) = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            info!("Heartbeat task shut down gracefully");
+        })
+    };
 
     // Spawn a task to handle events from the P2P node
-    tokio::spawn(async move {
-        while let Ok(event) = atoma_p2p_receiver.recv_async().await {
-            match event {
-                (
-                    AtomaP2pEvent::NodeMetricsRegistrationEvent {
-                        public_url,
-                        node_small_id,
-                        timestamp,
-                        country,
-                        node_metrics,
-                    },
-                    _,
-                ) => {
-                    info!(
-                        "Received node metrics registration: node_id={}, public_url={}, country={}, timestamp={}",
-                        node_small_id, public_url, country, timestamp
-                    );
-                    info!("Node metrics: {:?}", node_metrics);
+    let event_handler = tokio::spawn(async move {
+        let receiver = atoma_p2p_receiver;
+        let mut shutdown_receiver = shutdown_receiver.clone();
+
+        loop {
+            tokio::select! {
+                Ok(event) = receiver.recv_async() => {
+                    match event {
+                        (
+                            AtomaP2pEvent::NodeMetricsRegistrationEvent {
+                                public_url,
+                                node_small_id,
+                                timestamp,
+                                country,
+                                node_metrics,
+                            },
+                            _,
+                        ) => {
+                            info!(
+                                "Received node metrics registration: node_id={}, public_url={}, country={}, timestamp={}",
+                                node_small_id, public_url, country, timestamp
+                            );
+                            info!("Node metrics: {:?}", node_metrics);
+                        }
+                        (
+                            AtomaP2pEvent::VerifyNodeSmallIdOwnership {
+                                node_small_id,
+                                sui_address,
+                            },
+                            response_sender,
+                        ) => {
+                            info!(
+                                "Received node small ID ownership verification: node_id={}, sui_address={}",
+                                node_small_id, sui_address
+                            );
+                            // For testing purposes, always verify as true
+                            if let Some(sender) = response_sender {
+                                let _ = sender.send(true);
+                            }
+                        }
+                    }
                 }
-                (
-                    AtomaP2pEvent::VerifyNodeSmallIdOwnership {
-                        node_small_id,
-                        sui_address,
-                    },
-                    response_sender,
-                ) => {
-                    info!(
-                        "Received node small ID ownership verification: node_id={}, sui_address={}",
-                        node_small_id, sui_address
-                    );
-                    // For testing purposes, always verify as true
-                    if let Some(sender) = response_sender {
-                        let _ = sender.send(true);
+                Ok(()) = shutdown_receiver.changed() => {
+                    if *shutdown_receiver.borrow() {
+                        info!("Event handler received shutdown signal");
+                        break;
                     }
                 }
             }
         }
+        info!("Event handler terminated gracefully");
     });
 
     // Wait for Ctrl+C
@@ -115,8 +172,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Give some time for graceful shutdown
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Add timeout for graceful shutdown
+    info!("Waiting for components to shut down gracefully...");
+    let timeout = tokio::time::timeout(Duration::from_secs(5), atoma_p2p_node_handle).await;
+
+    match timeout {
+        Ok(result) => {
+            if let Err(e) = result {
+                error!("P2P node terminated with error: {:?}", e);
+            } else {
+                info!("P2P node shut down successfully");
+            }
+        }
+        Err(_) => {
+            error!("P2P node shutdown timed out after 5 seconds");
+        }
+    }
+
+    let heartbeat_result = tokio::time::timeout(Duration::from_secs(2), heartbeat_task).await;
+    let event_handler_result = tokio::time::timeout(Duration::from_secs(2), event_handler).await;
+
+    if let Ok(result) = heartbeat_result {
+        let _ = handle_task_result("Heartbeat", result);
+    }
+    if let Ok(result) = event_handler_result {
+        let _ = handle_task_result("Event Handler", result);
+    }
 
     Ok(())
+}
+
+fn handle_task_result<T>(
+    task_name: &str,
+    result: Result<T, tokio::task::JoinError>,
+) -> Result<T, tokio::task::JoinError> {
+    if let Err(e) = &result {
+        error!(
+            target = "atoma-p2p-tester",
+            event = "component_error",
+            component = task_name,
+            error = ?e,
+            "Component terminated with error"
+        );
+    } else {
+        info!(
+            target = "atoma-p2p-tester",
+            event = "component_shutdown",
+            component = task_name,
+            "Component shut down gracefully"
+        );
+    }
+    result
 }

--- a/atoma-p2p-tester/src/main.rs
+++ b/atoma-p2p-tester/src/main.rs
@@ -1,0 +1,122 @@
+use anyhow::{Context, Result};
+use atoma_daemon::telemetry;
+use atoma_p2p::{config::AtomaP2pNodeConfig, service::AtomaP2pNode, types::AtomaP2pEvent};
+use atoma_sui::config::Config as AtomaSuiConfig;
+use clap::Parser;
+use std::time::Duration;
+use std::{path::PathBuf, sync::Arc};
+use sui_keys::keystore::FileBasedKeystore;
+use tokio::signal;
+use tracing::{error, info};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the configuration file
+    #[arg(short, long)]
+    config_path: String,
+
+    /// Node ID (used to identify this node in logs)
+    #[arg(short, long, default_value = "1")]
+    node_id: u64,
+}
+
+struct Config {
+    sui: AtomaSuiConfig,
+
+    p2p: AtomaP2pNodeConfig,
+}
+
+impl Config {
+    pub fn load(config_path: &str) -> Self {
+        let config = AtomaP2pNodeConfig::from_file_path(config_path);
+        let sui_config = AtomaSuiConfig::from_file_path(config_path);
+        Self {
+            sui: sui_config,
+            p2p: config,
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Store both guards to keep logging active for the duration of the program
+    let (_file_guard, _stdout_guard) =
+        telemetry::setup_logging().context("Failed to setup logging")?;
+
+    info!(event = "startup", "Starting Atoma Proxy Service...");
+
+    let args = Args::parse();
+    tracing::info!("Loading configuration from: {}", args.config_path);
+
+    let config = Config::load(&args.config_path);
+    tracing::info!("Configuration loaded successfully");
+
+    // Create a channel to receive events from the P2P node
+    let (atoma_p2p_sender, atoma_p2p_receiver) = flume::unbounded();
+
+    // Create and start the P2P node
+    let keystore: FileBasedKeystore =
+        FileBasedKeystore::new(&PathBuf::from(&config.sui.sui_keystore_path()))?;
+
+    let _node = AtomaP2pNode::start(config.p2p, Arc::new(keystore), atoma_p2p_sender, false)?;
+
+    // Spawn a task to handle events from the P2P node
+    tokio::spawn(async move {
+        while let Ok(event) = atoma_p2p_receiver.recv_async().await {
+            match event {
+                (
+                    AtomaP2pEvent::NodeMetricsRegistrationEvent {
+                        public_url,
+                        node_small_id,
+                        timestamp,
+                        country,
+                        node_metrics,
+                    },
+                    _,
+                ) => {
+                    info!(
+                        "Received node metrics registration: node_id={}, public_url={}, country={}, timestamp={}",
+                        node_small_id, public_url, country, timestamp
+                    );
+                    info!("Node metrics: {:?}", node_metrics);
+                }
+                (
+                    AtomaP2pEvent::VerifyNodeSmallIdOwnership {
+                        node_small_id,
+                        sui_address,
+                    },
+                    response_sender,
+                ) => {
+                    info!(
+                        "Received node small ID ownership verification: node_id={}, sui_address={}",
+                        node_small_id, sui_address
+                    );
+                    // For testing purposes, always verify as true
+                    if let Some(sender) = response_sender {
+                        let _ = sender.send(true);
+                    }
+                }
+            }
+        }
+    });
+
+    // Wait for Ctrl+C
+    info!(
+        "P2P tester node {} is running. Press Ctrl+C to stop.",
+        args.node_id
+    );
+    match signal::ctrl_c().await {
+        Ok(()) => {
+            info!("Shutting down P2P tester node {}", args.node_id);
+        }
+        Err(err) => {
+            error!("Error waiting for Ctrl+C: {}", err);
+        }
+    }
+
+    // Give some time for graceful shutdown
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    Ok(())
+}

--- a/atoma-p2p/Cargo.toml
+++ b/atoma-p2p/Cargo.toml
@@ -24,6 +24,7 @@ libp2p = { workspace = true, features = [
 	"yamux",
 	"noise",
 	"metrics",
+	"rsa",
 ] }
 fastcrypto = { workspace = true }
 flume = { workspace = true }

--- a/atoma-p2p/src/config.rs
+++ b/atoma-p2p/src/config.rs
@@ -31,7 +31,7 @@ pub struct AtomaP2pNodeConfig {
     ///
     /// This is the address that the client/node will use to listen for incoming connections.
     /// It is a string in the format of "/ip4/x.x.x.x/udp/x/quic-v1".
-    pub listen_addr: String,
+    pub listen_addrs: Vec<String>,
 
     /// The public URL of the node (optional, as clients do not need to provide a public URL)
     ///

--- a/atoma-p2p/src/config.rs
+++ b/atoma-p2p/src/config.rs
@@ -43,12 +43,6 @@ pub struct AtomaP2pNodeConfig {
     /// The node's small id (assigned by the Atoma smart contract)
     pub node_small_id: Option<u64>,
 
-    /// The list of bootstrap nodes to connect to.
-    ///
-    /// Bootstrap nodes are nodes that the node will use to bootstrap its network connection.
-    /// They are a list of strings in the format of "/ip4/x.x.x.x/udp/x/quic-v1/p2p/QmHash...".
-    pub bootstrap_nodes: Vec<String>,
-
     /// The list of endpoints serving metrics to collect, displayed as a map of model name to a tuple
     /// of the form (`serving_engine`, `metrics_endpoint`)
     /// (e.g. `"meta-llama/Llama-3.2-3B-Instruct" => ("vllm", "http://chat-completions:8000/metrics")`)

--- a/atoma-p2p/src/errors.rs
+++ b/atoma-p2p/src/errors.rs
@@ -60,4 +60,6 @@ pub enum AtomaP2pNodeError {
     InvalidMessageLengthError,
     #[error("Failed to publish Message: `{0}`")]
     PublishError(String),
+    #[error("DNS resolver error: `{0}`")]
+    DnsError(#[from] std::io::Error),
 }

--- a/atoma-p2p/src/service.rs
+++ b/atoma-p2p/src/service.rs
@@ -44,9 +44,11 @@ const METRICS_GOSPUBSUB_TOPIC: &str = "atoma-p2p-usage-metrics";
 /// The interval at which the metrics are updated
 const METRICS_UPDATE_INTERVAL: Duration = Duration::from_secs(15);
 
+/// The protocol name for the Kademlia DHT
 const IPFS_PROTO_NAME: StreamProtocol = StreamProtocol::new("/ipfs/kad/1.0.0");
 
-const BOOTNODES: [&str; 4] = [
+// Well connected nodes to bootstrap the network (see https://docs.ipfs.tech/concepts/public-utilities/#amino-dht-bootstrappers)
+const BOOTSTRAP_NODES: [&str; 4] = [
     "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
     "QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
     "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
@@ -217,7 +219,6 @@ impl AtomaP2pNode {
         }
         let mut metrics_registry = libp2p::metrics::Registry::default();
 
-        // Create a random key for ourselves.
         let local_key = identity::Keypair::generate_ed25519();
 
         let mut swarm = SwarmBuilder::with_existing_identity(local_key)
@@ -385,7 +386,7 @@ impl AtomaP2pNode {
         );
 
         // Initialize Kademlia's bootstrap process
-        for peer_id in BOOTNODES {
+        for peer_id in BOOTSTRAP_NODES {
             match peer_id.parse::<PeerId>() {
                 Ok(peer_id) => {
                     swarm

--- a/atoma-p2p/src/service.rs
+++ b/atoma-p2p/src/service.rs
@@ -194,7 +194,7 @@ impl AtomaP2pNode {
     /// - Messages are signed using the node's private key
     /// - Peer connections are authenticated
     /// - The node validates all incoming messages
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn start(
         config: AtomaP2pNodeConfig,
         keystore: Arc<FileBasedKeystore>,
@@ -502,7 +502,7 @@ impl AtomaP2pNode {
     /// - Peer subscription/unsubscription events
     /// - Usage metrics processing errors
     /// - Shutdown events
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn run(
         mut self,
         mut shutdown_signal: watch::Receiver<bool>,

--- a/config.example.toml
+++ b/config.example.toml
@@ -47,14 +47,6 @@ listen_addr = "/ip4/0.0.0.0/udp/4001/quic-v1"
 node_small_id = 1
 # The HTTP(s) public URL of the node
 public_url = "https://<PUBLIC_URL>"
-# List of bootstrap nodes to connect to
-bootstrap_nodes = [
-    "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-    "QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-    "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-    "QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
-    "12D3KooWKnDdG3iXw9eTFijk3EWSunZcFi54Zka4wmtqtt6rPxc8",
-]
 # required, replace this with the country (ISO 3166-1 alpha-2) of the node (https://www.iso.org/obp/ui/#search/code/
 country = ""
 # List of endpoints serving metrics to collect, in the form of a map of model name to a tuple of (serving_engine, metrics_endpoint)

--- a/config.example.toml
+++ b/config.example.toml
@@ -42,7 +42,11 @@ heartbeat_interval = { secs = 30, nanos = 0 }
 # Maximum duration a connection can remain idle before closing (in seconds)
 idle_connection_timeout = { secs = 60, nanos = 0 }
 # Address to listen for incoming QUIC connections (format: "/ip4/x.x.x.x/udp/x")
-listen_addr = "/ip4/0.0.0.0/udp/4001/quic-v1"
+# Address to listen for incoming QUIC connections (format: "/ip4/x.x.x.x/udp/x")
+listen_addrs = [
+    "/ip4/0.0.0.0/tcp/4001",
+    "/ip4/0.0.0.0/udp/4001/quic-v1",
+]
 # Node's small ID (assigned by Atoma smart contract)
 node_small_id = 1
 # The HTTP(s) public URL of the node

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -8,5 +8,118 @@ services:
     ports:
       - 5432:5432
 
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    platform: ${PLATFORM:-}
+    restart: always
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    env_file: .env
+    networks:
+      - atoma-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:11.5.1
+    platform: ${PLATFORM:-}
+    restart: always
+    ports:
+      - "${GRAFANA_PORT:-30001}:3000"
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana_data:/var/lib/grafana
+    env_file: .env
+    environment:
+      - GF_SERVER_ROOT_URL=http://${GRAFANA_DOMAIN}:${GRAFANA_PORT:-30001}/
+    networks:
+      - atoma-network
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  loki:
+    image: grafana/loki:2.9.4
+    platform: ${PLATFORM:-}
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki.yaml:/etc/loki/loki.yaml
+      - loki-data:/loki
+    command: -config.file=/etc/loki/loki.yaml
+    networks:
+      - atoma-network
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  tempo:
+    image: grafana/tempo:2.7.0
+    platform: ${PLATFORM:-}
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - tempo-data:/tmp/tempo
+    ports:
+      - "3200:3200"
+    networks:
+      - atoma-network
+    user: "0"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3200/status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.119.0
+    platform: ${PLATFORM:-}
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+      - "8889:8889" # Prometheus exporter
+    networks:
+      - atoma-network
+    depends_on:
+      prometheus:
+        condition: service_healthy
+        required: true
+      grafana:
+        condition: service_healthy
+        required: true
+      loki:
+        condition: service_healthy
+        required: true
+      tempo:
+        condition: service_healthy
+        required: true
+networks:
+  atoma-network:
+    driver: bridge
+    name: atoma-network
+
 volumes:
   postgres-data:
+  prometheus-data:
+  grafana_data:
+  loki-data:
+  tempo-data:
+  otel-collector-data:


### PR DESCRIPTION
This PR creates a crate that will be used solely for testing the p2p-related functionality of the node, particularly the gossipsub metrics and health.

It also includes some fixes for connecting to bootstrap nodes and some fixes for `mdns`