### PR TITLE
feat: pass nvidia devices to atoma-node in docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,14 @@ x-atoma-node: &atoma-node
     context: .
     dockerfile: Dockerfile
   platform: ${PLATFORM:-} # Will be empty if not set
+  runtime: nvidia
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: all
+            capabilities: [gpu]
   volumes:
     - ${CONFIG_PATH:-./config.toml}:/app/config.toml
     - ./logs:/app/logs


### PR DESCRIPTION
Pass nvidia devices to atoma-node in the docker