### PR TITLE
feat: local key path from config

### DIFF
--- a/atoma-p2p/src/config.rs
+++ b/atoma-p2p/src/config.rs
@@ -50,6 +50,9 @@ pub struct AtomaP2pNodeConfig {
 
     /// The list of bootstrap nodes to dial
     pub bootstrap_node_addrs: Vec<String>,
+
+    /// The path to the local key
+    pub local_key: String,
 }
 
 impl AtomaP2pNodeConfig {

--- a/atoma-p2p/src/service.rs
+++ b/atoma-p2p/src/service.rs
@@ -49,9 +49,6 @@ const METRICS_UPDATE_INTERVAL: Duration = Duration::from_secs(15);
 /// The protocol name for the Kademlia DHT
 const IPFS_PROTO_NAME: StreamProtocol = StreamProtocol::new("/ipfs/kad/1.0.0");
 
-// The path to the local key
-const LOCAL_KEY_PATH: &str = "./local_key";
-
 // Well connected nodes to bootstrap the network (see https://docs.ipfs.tech/concepts/public-utilities/#amino-dht-bootstrappers)
 const IPFS_BOOTSTRAP_NODES: [&str; 4] = [
     "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
@@ -236,7 +233,9 @@ impl AtomaP2pNode {
                 .build()
                 .expect("Failed to build runtime");
 
-            rt.block_on(read_or_create_identity(Path::new(LOCAL_KEY_PATH)))
+            rt.block_on(read_or_create_identity(Path::new(
+                config.local_key.as_str(),
+            )))
         })
         .join()
         .expect("Thread panicked")?;

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,7 +18,7 @@ limit = 100                                                                     
 node_small_ids = [1]                                                                    # List of node IDs under control of the node wallet
 sui_config_path = "/root/.sui/sui_config/client.yaml"                                   # Path to the Sui client configuration file, accessed from the docker container (if this is not the case, pass in the full path, on your host machine which is by default ~/.sui/sui_config/client.yaml)
 sui_keystore_path = "/root/.sui/sui_config/sui.keystore"                                # Path to the Sui keystore file, accessed from the docker container (if this is not the case, pass in the full path, on your host machine which is by default ~/.sui/sui_config/sui.keystore)
-cursor_path = "./cursor.toml"                                                           # Path to the Sui events cursor file
+cursor_path = "/app/data/cursor.toml"                                                           # Path to the Sui events cursor file
 
 [atoma_state]
 # Path inside the container
@@ -62,3 +62,5 @@ country = ""
 # List of endpoints serving metrics to collect, in the form of a map of model name to a tuple of (serving_engine, metrics_endpoint)
 # (e.g. `"meta-llama/Llama-3.2-3B-Instruct" = ("vllm", "http://chat-completions:8000/metrics")`)
 metrics_endpoints = { "meta-llama/Llama-3.2-3B-Instruct" = ["vllm", "http://chat-completions:8000/metrics"] }
+# The path to the local key
+local_key = "/app/data/local_key"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,6 @@ x-atoma-node: &atoma-node
             capabilities: [gpu]
   volumes:
     - ${CONFIG_PATH:-./config.toml}:/app/config.toml
-    - ./local-key:/app/local_key
     - ./logs:/app/logs
     - sui-config-volume:/root/.sui/sui_config
     - ${SUI_CONFIG_PATH:-~/.sui/sui_config}:/tmp/.sui/sui_config


### PR DESCRIPTION
Map `local key` file from config.
Don't map files in `docker-compose.yml`
Change example config to use paths in the docker mapped folder `/app/data` instead of `./`
