### PR TITLE
feat: lock the concurrent request counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "atoma-sui",
  "atoma-utils",
  "config",
+ "dashmap 6.1.0",
  "flume",
  "futures",
  "serde",

--- a/atoma-service/src/handlers/chat_completions.rs
+++ b/atoma-service/src/handlers/chat_completions.rs
@@ -263,7 +263,7 @@ pub async fn chat_completions_handler(
             // will not be penalized for the request.
             //
             // NOTE: We also decrement the concurrent requests count, as we are done processing the request.
-            let concurrent_requests = handle_concurrent_requests_count_decrement(
+            handle_concurrent_requests_count_decrement(
                 &state.concurrent_requests_per_stack,
                 stack_small_id,
                 "chat-completions/chat_completions_handler",
@@ -274,7 +274,7 @@ pub async fn chat_completions_handler(
                 estimated_total_compute_units,
                 0,
                 &endpoint,
-                concurrent_requests,
+                &state.concurrent_requests_per_stack,
             )?;
             return Err(AtomaServiceError::InternalError {
                 message: format!("Error handling chat completions response: {}", e),
@@ -446,7 +446,7 @@ pub async fn confidential_chat_completions_handler(
             // will not be penalized for the request.
             //
             // NOTE: We also decrement the concurrent requests count, as we are done processing the request.
-            let concurrent_requests = handle_concurrent_requests_count_decrement(
+            handle_concurrent_requests_count_decrement(
                 &state.concurrent_requests_per_stack,
                 stack_small_id,
                 "chat-completions/confidential_chat_completions_handler",
@@ -457,7 +457,7 @@ pub async fn confidential_chat_completions_handler(
                 estimated_total_compute_units,
                 0,
                 &endpoint,
-                concurrent_requests,
+                &state.concurrent_requests_per_stack,
             )?;
             return Err(AtomaServiceError::InternalError {
                 message: format!("Error handling chat completions response: {}", e),
@@ -1446,7 +1446,7 @@ pub mod utils {
             level = "info",
             "Decrementing concurrent requests count for stack small id: {stack_small_id}"
         );
-        let concurrent_requests = handle_concurrent_requests_count_decrement(
+        handle_concurrent_requests_count_decrement(
             &state.concurrent_requests_per_stack,
             stack_small_id,
             "chat-completions/serve_non_streaming_response",
@@ -1462,7 +1462,7 @@ pub mod utils {
             estimated_total_compute_units,
             total_compute_units,
             &endpoint,
-            concurrent_requests,
+            &state.concurrent_requests_per_stack,
         )?;
 
         Ok(response_body)

--- a/atoma-service/src/handlers/embeddings.rs
+++ b/atoma-service/src/handlers/embeddings.rs
@@ -137,7 +137,7 @@ pub async fn embeddings_handler(
             TOTAL_FAILED_TEXT_EMBEDDING_REQUESTS
                 .add(1, &[KeyValue::new("model", model.as_str().to_owned())]);
             TOTAL_FAILED_REQUESTS.add(1, &[KeyValue::new("model", model.as_str().to_owned())]);
-            let concurrent_requests = handle_concurrent_requests_count_decrement(
+            handle_concurrent_requests_count_decrement(
                 &state.concurrent_requests_per_stack,
                 stack_small_id,
                 "embeddings/embeddings_handler",
@@ -148,7 +148,7 @@ pub async fn embeddings_handler(
                 estimated_total_compute_units,
                 0,
                 &endpoint,
-                concurrent_requests,
+                &state.concurrent_requests_per_stack,
             )?;
             Err(e)
         }
@@ -264,7 +264,7 @@ pub async fn confidential_embeddings_handler(
             TOTAL_FAILED_TEXT_EMBEDDING_CONFIDENTIAL_REQUESTS
                 .add(1, &[KeyValue::new("model", model.as_str().to_owned())]);
             TOTAL_FAILED_REQUESTS.add(1, &[KeyValue::new("model", model.as_str().to_owned())]);
-            let concurrent_requests = handle_concurrent_requests_count_decrement(
+            handle_concurrent_requests_count_decrement(
                 &state.concurrent_requests_per_stack,
                 stack_small_id,
                 "embeddings/confidential_embeddings_handler",
@@ -275,7 +275,7 @@ pub async fn confidential_embeddings_handler(
                 estimated_total_compute_units,
                 0,
                 &endpoint,
-                concurrent_requests,
+                &state.concurrent_requests_per_stack,
             )?;
             Err(e)
         }

--- a/atoma-service/src/handlers/image_generations.rs
+++ b/atoma-service/src/handlers/image_generations.rs
@@ -136,7 +136,7 @@ pub async fn image_generations_handler(
             TOTAL_FAILED_REQUESTS.add(1, &[KeyValue::new("model", model.to_owned())]);
             TOTAL_FAILED_IMAGE_GENERATION_REQUESTS
                 .add(1, &[KeyValue::new("model", model.to_owned())]);
-            let concurrent_requests = handle_concurrent_requests_count_decrement(
+            handle_concurrent_requests_count_decrement(
                 &state.concurrent_requests_per_stack,
                 stack_small_id,
                 "image-generations/image_generations_handler",
@@ -147,7 +147,7 @@ pub async fn image_generations_handler(
                 estimated_total_compute_units,
                 0,
                 &endpoint,
-                concurrent_requests,
+                &state.concurrent_requests_per_stack,
             )?;
             Err(AtomaServiceError::InternalError {
                 message: format!("Error handling image generations response: {}", e),
@@ -258,7 +258,7 @@ pub async fn confidential_image_generations_handler(
             TOTAL_FAILED_REQUESTS.add(1, &[KeyValue::new("model", model.clone())]);
             TOTAL_FAILED_IMAGE_CONFIDENTIAL_GENERATION_REQUESTS
                 .add(1, &[KeyValue::new("model", model.clone())]);
-            let concurrent_requests = handle_concurrent_requests_count_decrement(
+            handle_concurrent_requests_count_decrement(
                 &state.concurrent_requests_per_stack,
                 stack_small_id,
                 "image-generations/confidential_image_generations_handler",
@@ -269,7 +269,7 @@ pub async fn confidential_image_generations_handler(
                 estimated_total_compute_units,
                 0,
                 &endpoint,
-                concurrent_requests,
+                &state.concurrent_requests_per_stack,
             )?;
             Err(AtomaServiceError::InternalError {
                 message: format!("Error handling image generations response: {}", e),

--- a/atoma-service/src/handlers/mod.rs
+++ b/atoma-service/src/handlers/mod.rs
@@ -5,6 +5,8 @@ pub mod metrics;
 pub mod request_model;
 pub mod stop_streamer;
 
+use std::sync::Arc;
+
 use atoma_confidential::types::{
     ConfidentialComputeEncryptionRequest, ConfidentialComputeEncryptionResponse,
 };
@@ -303,14 +305,14 @@ pub fn update_stack_num_compute_units(
     estimated_total_compute_units: i64,
     total_compute_units: i64,
     endpoint: &str,
-    concurrent_requests: u64,
+    concurrent_requests: &Arc<DashMap<i64, u64>>,
 ) -> Result<(), AtomaServiceError> {
     state_manager_sender
         .send(AtomaAtomaStateManagerEvent::UpdateStackNumComputeUnits {
             stack_small_id,
             total_compute_units,
             estimated_total_compute_units,
-            concurrent_requests,
+            concurrent_requests: Arc::clone(concurrent_requests),
         })
         .map_err(|e| AtomaServiceError::InternalError {
             message: format!("Error sending update stack num compute units event: {e}"),
@@ -353,7 +355,7 @@ pub fn handle_concurrent_requests_count_decrement(
     concurrent_requests_per_stack: &DashMap<i64, u64>,
     stack_small_id: i64,
     endpoint: &str,
-) -> u64 {
+) {
     let entry = concurrent_requests_per_stack.entry(stack_small_id);
     match entry {
         dashmap::mapref::entry::Entry::Occupied(mut occupied_entry) => {
@@ -365,7 +367,6 @@ pub fn handle_concurrent_requests_count_decrement(
                     endpoint = endpoint,
                 );
                 occupied_entry.remove();
-                0
             } else {
                 let new_count = current_count.saturating_sub(1);
                 occupied_entry.insert(new_count);
@@ -379,7 +380,6 @@ pub fn handle_concurrent_requests_count_decrement(
                     );
                     occupied_entry.remove();
                 }
-                new_count
             }
         }
         dashmap::mapref::entry::Entry::Vacant(_) => {
@@ -391,7 +391,6 @@ pub fn handle_concurrent_requests_count_decrement(
                 stack_small_id,
                 "Attempted to decrement concurrent requests for non-existent stack entry (implies count is 0).",
             );
-            0
         }
     }
 }

--- a/atoma-service/src/streamer.rs
+++ b/atoma-service/src/streamer.rs
@@ -336,7 +336,7 @@ impl Streamer {
         }
 
         // Update stack num tokens
-        let num_concurrent_requests = handle_concurrent_requests_count_decrement(
+        handle_concurrent_requests_count_decrement(
             &self.concurrent_requests,
             self.stack_small_id,
             &self.endpoint,
@@ -347,7 +347,7 @@ impl Streamer {
             self.estimated_total_compute_units,
             total_compute_units as i64,
             &self.endpoint,
-            num_concurrent_requests,
+            &self.concurrent_requests,
         ) {
             error!(
                 target = "atoma-service-streamer",
@@ -814,7 +814,7 @@ impl Streamer {
         // will not be penalized for the failed request.
         //
         // NOTE: We also decrement the concurrent requests count, as we are done processing the request.
-        let num_concurrent_requests = handle_concurrent_requests_count_decrement(
+        handle_concurrent_requests_count_decrement(
             &self.concurrent_requests,
             self.stack_small_id,
             &self.endpoint,
@@ -825,7 +825,7 @@ impl Streamer {
             self.estimated_total_compute_units,
             0,
             &self.endpoint,
-            num_concurrent_requests,
+            &self.concurrent_requests,
         ) {
             error!(
                 target = "atoma-service-streamer",
@@ -907,7 +907,7 @@ impl Drop for Streamer {
                 ],
             );
         }
-        let num_concurrent_requests = handle_concurrent_requests_count_decrement(
+        handle_concurrent_requests_count_decrement(
             &self.concurrent_requests,
             self.stack_small_id,
             &self.endpoint,
@@ -918,7 +918,7 @@ impl Drop for Streamer {
             self.estimated_total_compute_units,
             self.num_input_tokens + self.streamer_computed_num_tokens,
             &self.endpoint,
-            num_concurrent_requests,
+            &self.concurrent_requests,
         ) {
             error!(
                 target = "atoma-service-streamer",

--- a/atoma-state/Cargo.toml
+++ b/atoma-state/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 atoma-p2p  = { workspace = true }
 atoma-sui  = { workspace = true }
 config     = { workspace = true }
+dashmap    = { workspace = true }
 flume      = { workspace = true }
 serde      = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -848,6 +848,12 @@ pub(crate) async fn handle_update_stack_num_compute_units_and_claim_funds(
                 )
             }
             Entry::Vacant(_entry) => {
+                error!(
+                    target = "atoma-state-handlers",
+                    event = "handle-update-stack-num-compute-units-and-claim-funds",
+                    "Stack {} not found in concurrent requests",
+                    stack_small_id
+                );
                 return Err(AtomaStateManagerError::StackNotFound);
             }
         }

--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -829,7 +829,7 @@ pub(crate) async fn handle_update_stack_num_compute_units_and_claim_funds(
         },
         concurrent_requests,
     ) = match entry {
-        Entry::Occupied(entry) => {
+        Entry::Occupied(ref entry) => {
             let count = *entry.get();
             (
                 state_manager
@@ -849,6 +849,7 @@ pub(crate) async fn handle_update_stack_num_compute_units_and_claim_funds(
             return Err(AtomaStateManagerError::StackNotFound);
         }
     };
+    drop(entry);
     info!(
         target = "atoma-state-handlers",
         event = "handle-update-stack-num-compute-units-and-claim-funds",

--- a/atoma-state/src/types.rs
+++ b/atoma-state/src/types.rs
@@ -3,9 +3,10 @@ use atoma_sui::events::{
     StackAttestationDisputeEvent, StackCreateAndUpdateEvent, StackCreatedEvent,
     StackTrySettleEvent, TaskRegisteredEvent,
 };
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
-use std::result::Result;
+use std::{result::Result, sync::Arc};
 use tokio::sync::oneshot;
 use utoipa::ToSchema;
 
@@ -260,7 +261,7 @@ pub enum AtomaAtomaStateManagerEvent {
         /// Total number of compute units in the stack
         total_compute_units: i64,
         /// Number of concurrent requests for the stack
-        concurrent_requests: u64,
+        concurrent_requests: Arc<DashMap<i64, u64>>,
     },
     /// Represents an update to the total hash of a stack
     UpdateStackTotalHash {


### PR DESCRIPTION
Lock the concurrent request counter, so it should never call the claim stack twice.