### PR TITLE
fix: propagate too many requests to proxy

### DIFF
--- a/atoma-service/src/handlers/chat_completions.rs
+++ b/atoma-service/src/handlers/chat_completions.rs
@@ -277,6 +277,7 @@ pub async fn chat_completions_handler(
                 concurrent_requests,
             )?;
             match e {
+                // We want to propagate the error if the inference service is unavailable
                 AtomaServiceError::ChatCompletionsServiceUnavailable { .. } => Err(e),
                 _ => Err(AtomaServiceError::InternalError {
                     message: format!("Error handling chat completions response: {}", e),

--- a/atoma-service/src/handlers/chat_completions.rs
+++ b/atoma-service/src/handlers/chat_completions.rs
@@ -276,10 +276,13 @@ pub async fn chat_completions_handler(
                 &endpoint,
                 concurrent_requests,
             )?;
-            return Err(AtomaServiceError::InternalError {
-                message: format!("Error handling chat completions response: {}", e),
-                endpoint: request_metadata.endpoint_path.clone(),
-            });
+            match e {
+                AtomaServiceError::ChatCompletionsServiceUnavailable { .. } => Err(e),
+                _ => Err(AtomaServiceError::InternalError {
+                    message: format!("Error handling chat completions response: {}", e),
+                    endpoint: request_metadata.endpoint_path.clone(),
+                }),
+            }
         }
     }
 }


### PR DESCRIPTION
We need to propage the error if the inference is not available (or too many requests).