### PR TITLE
fix: add prom metrics querying to background tasks

### DIFF
--- a/atoma-bin/atoma_node.rs
+++ b/atoma-bin/atoma_node.rs
@@ -403,7 +403,10 @@ async fn main() -> Result<()> {
         }
     }
 
-    start_metrics_updater(chat_completions_service_urls);
+    start_metrics_updater(
+        chat_completions_service_urls,
+        config.service.metrics_update_interval,
+    );
 
     let daemon_app_state = DaemonState {
         atoma_state: AtomaState::new_from_url(&config.state.database_url).await?,

--- a/atoma-service/src/config.rs
+++ b/atoma-service/src/config.rs
@@ -53,6 +53,9 @@ pub struct AtomaServiceConfig {
 
     /// The environment for the Atoma Service.
     pub environment: Option<String>,
+
+    /// The interval for updating the metrics.
+    pub metrics_update_interval: Option<u64>,
 }
 
 impl AtomaServiceConfig {

--- a/atoma-service/src/handlers/metrics.rs
+++ b/atoma-service/src/handlers/metrics.rs
@@ -217,6 +217,25 @@ pub static CHAT_COMPLETIONS_STREAMING_LATENCY_METRICS: LazyLock<Histogram<f64>> 
             .build()
     });
 
+/// Counter metric that tracks the number of times the chat completions service is unavailable.
+///
+/// This metric counts the number of times the chat completions service is unavailable,
+/// broken down by model type. This helps monitor the availability of the chat completions service.
+///
+/// # Metric Details
+/// - Name: `atoma_chat_completions_service_unavailable`
+/// - Description: The number of times the chat completions service is unavailable
+/// - Unit: requests (count)
+/// - Labels: `model`
+/// - Type: Counter
+pub static CHAT_COMPLETIONS_TOO_MANY_REQUESTS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    GLOBAL_METER
+        .u64_counter("atoma_chat_completions_too_many_requests")
+        .with_description("The number of times the chat completions service is unavailable")
+        .with_unit("requests")
+        .build()
+});
+
 /// Histogram metric that tracks the latency of image generation requests.
 ///
 /// This metric measures the time taken to generate images, broken down by model type.

--- a/atoma-service/src/handlers/mod.rs
+++ b/atoma-service/src/handlers/mod.rs
@@ -616,9 +616,8 @@ pub mod vllm_metrics {
                 }
             };
             if request_queue_time_seconds.is_nan() {
-                continue;
-            }
-            if request_queue_time_seconds < min_request_queue_time_seconds {
+                min_request_queue_time_seconds = 0.0;
+            } else if request_queue_time_seconds < min_request_queue_time_seconds {
                 debug!(
                     target = "atoma-service",
                     module = "vllm_metrics",

--- a/atoma-service/src/handlers/mod.rs
+++ b/atoma-service/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::duplicate_mod)]
 pub mod chat_completions;
 pub mod embeddings;
 pub mod image_generations;
@@ -60,7 +61,7 @@ pub const USAGE_KEY: &str = "usage";
     fields(event = "sign-response-and-update-stack-hash",),
     err
 )]
-async fn sign_response_and_update_stack_hash(
+pub async fn sign_response_and_update_stack_hash(
     response_body: &mut Value,
     payload_hash: [u8; 32],
     state: &AppState,
@@ -436,14 +437,23 @@ pub fn handle_status_code_error(
     }
 }
 
-mod vllm_metrics {
+pub mod vllm_metrics {
+    use std::sync::Arc;
     use std::sync::LazyLock;
+    use std::time::Duration;
+    use tokio::sync::RwLock;
+    use tokio::time;
 
     use hyper::StatusCode;
     use prometheus_http_query::Client;
     use tracing::{info, instrument};
 
     pub type Result<T> = std::result::Result<T, VllmMetricsError>;
+    type MetricValue = (String, f64);
+    type MetricResult = Result<MetricValue>;
+    type MetricsVec = Vec<MetricResult>;
+    type CachedMetrics = Option<MetricsVec>;
+    type MetricsLock = Arc<RwLock<CachedMetrics>>;
 
     /// The timeout for the Prometheus metrics queries
     const METRICS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
@@ -463,29 +473,46 @@ mod vllm_metrics {
         .expect("Failed to create HTTP client")
     });
 
+    /// Cache structure to store metrics
+    #[derive(Debug, Default)]
+    struct MetricsCache {
+        metrics: MetricsLock,
+    }
+
+    impl MetricsCache {
+        fn new() -> Self {
+            Self {
+                metrics: Arc::new(RwLock::new(None)),
+            }
+        }
+
+        async fn get_metrics(&self) -> Option<Vec<Result<(String, f64)>>> {
+            self.metrics.read().await.clone()
+        }
+
+        async fn update_metrics(&self, new_metrics: Vec<Result<(String, f64)>>) {
+            *self.metrics.write().await = Some(new_metrics);
+        }
+    }
+
+    /// Global metrics cache
+    #[allow(clippy::redundant_closure)]
+    static METRICS_CACHE: LazyLock<MetricsCache> = LazyLock::new(|| MetricsCache::new());
+
+    /// Start the background task to update metrics every 30 seconds
+    pub fn start_metrics_updater(chat_completions_service_urls: Vec<(String, String)>) {
+        let chat_completions_service_urls = Arc::new(chat_completions_service_urls);
+        tokio::spawn(async move {
+            let mut interval = time::interval(Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                let metrics = get_metrics(&HTTP_CLIENT, &chat_completions_service_urls).await;
+                METRICS_CACHE.update_metrics(metrics).await;
+            }
+        });
+    }
+
     /// Retrieves the 90th percentile request queue time metric from a vLLM service.
-    ///
-    /// This function executes a Prometheus query against the configured Prometheus instance
-    /// to get the `vllm:request_queue_time_seconds` histogram for the specified `job`,
-    /// calculates the 90th percentile, and returns it along with the service URL.
-    ///
-    /// # Arguments
-    ///
-    /// * `client` - The Prometheus HTTP query client.
-    /// * `jobs_with_url` - The Prometheus job names corresponding to the vLLM service instances alongside with the chat completions service url.
-    ///
-    /// # Returns
-    ///
-    /// Returns a vector of `Result` containing a tuple `(String, f64)` on success, where:
-    ///   - The `String` is the `chat_completions_service_url` passed as input.
-    ///   - The `f64` is the calculated 90th percentile of the request queue time in seconds.
-    ///
-    /// # Errors
-    ///
-    /// Return contains a `VllmMetricsError` if:
-    ///   - The Prometheus query fails.
-    ///   - No metrics data is found for the specified job.
-    ///   - The response data cannot be parsed correctly.
     #[instrument(level = "info", skip_all, fields(jobs_with_url=jobs_with_url.iter().map(|(url, job)| format!("{job}={url}")).collect::<Vec<_>>().join(",")))]
     async fn get_metrics(
         client: &Client,
@@ -532,24 +559,7 @@ mod vllm_metrics {
     }
 
     /// Retrieves the best available chat completions service URL for a given model.
-    ///
-    /// This function iterates through a list of chat completions service URLs,
-    /// executes a Prometheus query to retrieve request queue time metrics,
-    /// and selects the URL with the lowest request queue time.
-    ///
-    /// # Arguments
-    ///
-    /// * `chat_completions_service_urls` - A list of chat completions service URLs together with respective job names to query
-    /// * `model` - The name of the model to query
-    ///
-    /// # Returns
-    ///
-    /// Returns the URL of the chat completions service with the lowest request queue time.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `VllmMetricsError` if the list of chat completions service URLs is empty.
-    #[instrument(level = "info", skip_all, fields(model=model, chat_completions_service_urls=chat_completions_service_urls.len()))]
+    #[instrument(level = "info", skip_all, fields(model=model))]
     pub async fn get_best_available_chat_completions_service_url(
         chat_completions_service_urls: &[(String, String)],
         model: &str,
@@ -560,18 +570,28 @@ mod vllm_metrics {
                 model.to_string(),
             ));
         }
+
         let mut min_request_queue_time_seconds = MAX_ALLOWED_REQUEST_QUEUE_TIME_SECONDS;
         let mut best_url = chat_completions_service_urls[0].0.clone();
-        let metrics = get_metrics(&HTTP_CLIENT, chat_completions_service_urls).await;
+
+        // Get cached metrics
+        let metrics = match METRICS_CACHE.get_metrics().await {
+            Some(metrics) => metrics,
+            None => {
+                // If no cached metrics, get them directly
+                get_metrics(&HTTP_CLIENT, chat_completions_service_urls).await
+            }
+        };
+
         for metric in metrics {
             let (chat_completions_service_url, request_queue_time_seconds) = match metric {
                 Ok((chat_completions_service_url, request_queue_time_seconds)) => {
                     info!(
-                            target = "atoma-service",
-                            module = "vllm_metrics",
-                            level = "info",
-                            "Received vLLM request queue time metrics response for {chat_completions_service_url}: {request_queue_time_seconds}"
-                        );
+                        target = "atoma-service",
+                        module = "vllm_metrics",
+                        level = "info",
+                        "Received vLLM request queue time metrics response for {chat_completions_service_url}: {request_queue_time_seconds}"
+                    );
                     (chat_completions_service_url, request_queue_time_seconds)
                 }
                 Err(e) => {
@@ -602,7 +622,7 @@ mod vllm_metrics {
             model = model,
             best_url = best_url
         );
-        if min_request_queue_time_seconds >= MAX_ALLOWED_REQUEST_QUEUE_TIME_SECONDS {
+        if min_request_queue_time_seconds > MAX_ALLOWED_REQUEST_QUEUE_TIME_SECONDS {
             tracing::warn!(
                 target = "atoma-service",
                 level = "warn",
@@ -613,19 +633,44 @@ mod vllm_metrics {
         Ok((best_url, StatusCode::OK))
     }
 
-    #[derive(Debug, thiserror::Error)]
+    #[derive(Debug, thiserror::Error, Clone)]
     pub enum VllmMetricsError {
         #[error("Failed to get metrics: {0}")]
-        GetMetricsError(#[from] reqwest::Error),
+        GetMetricsError(String),
         #[error("No chat completions service urls found for model: {0}")]
         NoChatCompletionsServiceUrlsFound(String),
         #[error("Invalid metrics value: {0}")]
-        InvalidMetricsValue(#[from] std::num::ParseFloatError),
+        InvalidMetricsValue(String),
         #[error("Invalid metrics response: {0}")]
-        InvalidMetricsResponse(#[from] serde_json::Error),
+        InvalidMetricsResponse(String),
         #[error("Failed to create HTTP client: {0}")]
-        FailedToCreateHttpClient(#[from] prometheus_http_query::Error),
+        FailedToCreateHttpClient(String),
         #[error("No metrics found for job: {0}")]
         NoMetricsFound(String),
+    }
+
+    // From implementations to handle conversions from error types to our cloneable error type
+    impl From<reqwest::Error> for VllmMetricsError {
+        fn from(err: reqwest::Error) -> Self {
+            Self::GetMetricsError(err.to_string())
+        }
+    }
+
+    impl From<std::num::ParseFloatError> for VllmMetricsError {
+        fn from(err: std::num::ParseFloatError) -> Self {
+            Self::InvalidMetricsValue(err.to_string())
+        }
+    }
+
+    impl From<serde_json::Error> for VllmMetricsError {
+        fn from(err: serde_json::Error) -> Self {
+            Self::InvalidMetricsResponse(err.to_string())
+        }
+    }
+
+    impl From<prometheus_http_query::Error> for VllmMetricsError {
+        fn from(err: prometheus_http_query::Error) -> Self {
+            Self::FailedToCreateHttpClient(err.to_string())
+        }
     }
 }

--- a/atoma-service/src/handlers/mod.rs
+++ b/atoma-service/src/handlers/mod.rs
@@ -438,12 +438,14 @@ pub fn handle_status_code_error(
 }
 
 pub mod vllm_metrics {
+    use opentelemetry::KeyValue;
     use std::sync::Arc;
     use std::sync::LazyLock;
     use std::time::Duration;
     use tokio::sync::RwLock;
     use tokio::time;
 
+    use crate::handlers::metrics::CHAT_COMPLETIONS_TOO_MANY_REQUESTS;
     use hyper::StatusCode;
     use prometheus_http_query::Client;
     use tracing::{info, instrument};
@@ -628,6 +630,7 @@ pub mod vllm_metrics {
                 level = "warn",
                 "Best available chat completions service URL for model: {model} has a request queue time of at least {min_request_queue_time_seconds} seconds",
             );
+            CHAT_COMPLETIONS_TOO_MANY_REQUESTS.add(1, &[KeyValue::new("model", model.to_string())]);
             return Ok((best_url, StatusCode::TOO_MANY_REQUESTS));
         }
         Ok((best_url, StatusCode::OK))

--- a/atoma-service/src/handlers/request_model.rs
+++ b/atoma-service/src/handlers/request_model.rs
@@ -17,7 +17,6 @@ pub struct ComputeUnitsEstimate {
 ///
 /// This trait provides a common interface for processing various types of AI model requests
 /// and estimating their computational costs.
-///
 pub trait RequestModel {
     /// Constructs a new request model instance by parsing the provided JSON request.
     ///

--- a/atoma-service/src/handlers/request_model.rs
+++ b/atoma-service/src/handlers/request_model.rs
@@ -14,8 +14,10 @@ pub struct ComputeUnitsEstimate {
 }
 
 /// A trait for parsing and handling AI model requests across different endpoints (chat, embeddings, images).
+///
 /// This trait provides a common interface for processing various types of AI model requests
 /// and estimating their computational costs.
+///
 pub trait RequestModel {
     /// Constructs a new request model instance by parsing the provided JSON request.
     ///
@@ -25,6 +27,9 @@ pub trait RequestModel {
     /// # Returns
     /// * `Ok(Self)` - Successfully parsed request model
     /// * `Err(AtomaProxyError)` - If the request is invalid or malformed
+    ///
+    /// # Errors
+    /// Returns `AtomaServiceError` if the request is invalid or malformed
     fn new(request: &Value) -> Result<Self, AtomaServiceError>
     where
         Self: Sized;
@@ -37,6 +42,9 @@ pub trait RequestModel {
     /// # Returns
     /// * `Ok(u64)` - The estimated compute units needed
     /// * `Err(AtomaProxyError)` - If the estimation fails or parameters are invalid
+    ///
+    /// # Errors
+    /// Returns `AtomaServiceError` if the estimation fails or parameters are invalid
     ///
     /// # Warning
     /// This method assumes that the tokenizer has been correctly retrieved from the `ProxyState` for

--- a/atoma-service/src/lib.rs
+++ b/atoma-service/src/lib.rs
@@ -15,7 +15,7 @@
 pub(crate) mod components;
 pub mod config;
 pub mod error;
-pub(crate) mod handlers;
+pub mod handlers;
 pub mod middleware;
 pub mod server;
 pub mod streamer;

--- a/config.example.toml
+++ b/config.example.toml
@@ -36,12 +36,13 @@ chat_completions_service_urls = { "Infermatic/Llama-3.3-70B-Instruct-FP8-Dynamic
 embeddings_service_url = "http://embeddings:80"
 image_generations_service_url = "http://image-generations:80"
 # List of models to be used by the service, the current value here is just a placeholder, please change it to the models you want to deploy
-environment          = "development"                                       # or "production" (for use in sentry, you need to set the Sentry DSN)
-heartbeat_url        = "my-heartbeat-url"
-models               = [ "Infermatic/Llama-3.3-70B-Instruct-FP8-Dynamic" ]
-revisions            = [ "main" ]
-sentry_dsn           = ""                                                  # Sentry DSN (for use in sentry, you need to set the Sentry DSN)
-service_bind_address = "0.0.0.0:3000"
+environment             = "development"                                       # or "production" (for use in sentry, you need to set the Sentry DSN)
+heartbeat_url           = "my-heartbeat-url"
+metrics_update_interval = 30
+models                  = [ "Infermatic/Llama-3.3-70B-Instruct-FP8-Dynamic" ]
+revisions               = [ "main" ]
+sentry_dsn              = ""                                                  # Sentry DSN (for use in sentry, you need to set the Sentry DSN)
+service_bind_address    = "0.0.0.0:3000"
 
 [atoma_sui]
 atoma_db                = "0x02920289f426dd1f3c2572d613f7dc92be95041720864a73d44d65585530efc5" # Current ATOMA DB object ID for testnet


### PR DESCRIPTION
Through our tests we found that  prometheus was failing to query the vllm for metrics, this is because for each request prometheus had to run a query to find the availability of the last 30 seconds. This is unreasonable because realistically this statistic would only update at less frequent intervals, and so we could just use the recently cached value.

So we run the metrics as a background task that updates this cache regularly. If no error is returned we proceed with the chat completion request. 