### PR TITLE
chore: remove timestamp

### DIFF
--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -39,13 +39,13 @@ pub async fn handle_atoma_event(
         AtomaEvent::NodeUnsubscribedFromTaskEvent(event) => {
             handle_node_task_unsubscription_event(state_manager, event).await
         }
-        AtomaEvent::StackCreatedEvent((event, _)) => {
+        AtomaEvent::StackCreatedEvent(event) => {
             handle_stack_created_event(state_manager, event).await
         }
         AtomaEvent::StackCreateAndUpdateEvent(event) => {
             handle_stack_create_and_update_event(state_manager, event).await
         }
-        AtomaEvent::StackTrySettleEvent((event, _)) => {
+        AtomaEvent::StackTrySettleEvent(event) => {
             handle_stack_try_settle_event(state_manager, event).await
         }
         AtomaEvent::StackSettlementTicketEvent(event) => {

--- a/atoma-sui/src/events.rs
+++ b/atoma-sui/src/events.rs
@@ -143,13 +143,13 @@ pub enum AtomaEvent {
     TaskRemovedEvent(TaskRemovedEvent),
 
     /// An event emitted when a new stack (collection of tasks) is created.
-    StackCreatedEvent((StackCreatedEvent, Option<u64>)),
+    StackCreatedEvent(StackCreatedEvent),
 
     /// An event emitted when a stack is created and updated simultaneously with already computed compute units.
     StackCreateAndUpdateEvent(StackCreateAndUpdateEvent),
 
     /// An event emitted when there's an attempt to settle a stack.
-    StackTrySettleEvent((StackTrySettleEvent, Option<u64>)),
+    StackTrySettleEvent(StackTrySettleEvent),
 
     /// An event emitted when a new attestation is made for a stack settlement.
     NewStackSettlementAttestationEvent(NewStackSettlementAttestationEvent),


### PR DESCRIPTION
This is not needed anymore, it was used for stats on proxy, but now we get stats from grafana.