### PR TITLE
feat: get metrics directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prometheus",
  "prometheus-http-query",
+ "prometheus-parse",
  "rand 0.8.5",
  "reqwest",
  "sentry",
@@ -6797,6 +6798,18 @@ dependencies = [
  "serde",
  "time",
  "url",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ opentelemetry-otlp          = "0.27.0"
 opentelemetry_sdk           = "0.27.0"
 prometheus                  = "0.13.4"
 prometheus-http-query       = "0.8.3"
+prometheus-parse            = "0.2.5"
 rand                        = "0.8.5"
 remote-attestation-verifier = { git = "https://github.com/atoma-network/nvrust.git", branch = "main", package = "remote-attestation-verifier" }
 reqwest                     = "0.12.12"

--- a/atoma-service/Cargo.toml
+++ b/atoma-service/Cargo.toml
@@ -39,6 +39,7 @@ opentelemetry-otlp = { workspace = true, features = [
 opentelemetry_sdk = { workspace = true, features = [ "logs", "metrics", "rt-tokio", "trace" ] }
 prometheus = { workspace = true }
 prometheus-http-query = { workspace = true }
+prometheus-parse = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = [ "json" ] }
 sentry = { workspace = true }

--- a/atoma-service/src/handlers/mod.rs
+++ b/atoma-service/src/handlers/mod.rs
@@ -551,8 +551,6 @@ pub mod inference_service_metrics {
     /// The default interval for updating the metrics
     const DEFAULT_METRICS_UPDATE_INTERVAL_MILLIS: u64 = 1_000;
 
-    /// The timeout for the Prometheus metrics queries
-    const METRICS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
     /// Chat completions metrics
     #[derive(Debug, Clone)]
     struct ChatCompletionsMetrics {
@@ -659,12 +657,6 @@ pub mod inference_service_metrics {
                         &sglang_chat_completions_service_urls,
                     )
                     .await;
-                    info!(
-                        target = "atoma-service",
-                        module = "inference_service_metrics",
-                        level = "info",
-                        "Received SgLang metrics response for {sglang_chat_completions_service_urls:?}, {sglang_metrics:?}"
-                    );
                     if sglang_metrics.iter().any(std::result::Result::is_ok) {
                         SGLANG_METRICS_CACHE.update_metrics(sglang_metrics).await;
                     } else {


### PR DESCRIPTION
Metrics are now not periodic, but on each request, directly from the inference service. We don't use TTFT or queue time anymore. Just the number of running and number of queued requests.