### PR TITLE
feat: add usage per user/model/day

### DIFF
--- a/atoma-state/src/handlers.rs
+++ b/atoma-state/src/handlers.rs
@@ -803,6 +803,18 @@ pub(crate) async fn handle_state_manager_event(
             if output_amount > 0 {
                 state_manager
                     .state
+                    .update_per_day_table(
+                        0, // TODO: Change this to the correct user_id when available
+                        user_address.clone(),
+                        model_name.clone(),
+                        estimated_input_amount,
+                        input_amount,
+                        estimated_output_amount,
+                        output_amount,
+                    )
+                    .await?;
+                state_manager
+                    .state
                     .update_usage_per_model(
                         user_address,
                         model_name,

--- a/atoma-state/src/migrations/20250528104721_usage-per-day.sql
+++ b/atoma-state/src/migrations/20250528104721_usage-per-day.sql
@@ -1,0 +1,12 @@
+CREATE TABLE
+  IF NOT EXISTS usage_per_day (
+    user_id BIGINT NOT NULL,
+    user_address TEXT NOT NULL,
+    date DATE DEFAULT CURRENT_DATE NOT NULL,
+    model TEXT NOT NULL,
+    input_amount BIGINT NOT NULL DEFAULT 0,
+    input_tokens BIGINT NOT NULL DEFAULT 0,
+    output_amount BIGINT NOT NULL DEFAULT 0,
+    output_tokens BIGINT NOT NULL DEFAULT 0,
+    UNIQUE (user_id, user_address, date, model)
+  );


### PR DESCRIPTION
Add usage per day per user per model. The usage includes the input/output amount(USD)/tokens. I didn't wanted to include the total, because that's computable from the table, so we are saving space.