### PR TITLE
feat: turn on too many requests for a period of time

### DIFF
--- a/atoma-bin/atoma_node.rs
+++ b/atoma-bin/atoma_node.rs
@@ -371,6 +371,8 @@ async fn main() -> Result<()> {
         keystore: Arc::new(keystore),
         address_index,
         whitelist_sui_addresses_for_fiat: config.service.whitelist_sui_addresses_for_fiat,
+        too_many_requests: Arc::new(DashMap::new()),
+        too_many_requests_timeout_ms: u128::from(config.service.too_many_requests_timeout_ms),
     };
 
     let chat_completions_service_urls = app_state

--- a/atoma-service/src/config.rs
+++ b/atoma-service/src/config.rs
@@ -57,6 +57,9 @@ pub struct AtomaServiceConfig {
 
     /// List of allowed sui addresses for fiat payments.
     pub whitelist_sui_addresses_for_fiat: Vec<String>,
+
+    /// The timeout for the too many requests error in milliseconds.
+    pub too_many_requests_timeout_ms: u64,
 }
 
 impl AtomaServiceConfig {

--- a/atoma-service/src/handlers/chat_completions.rs
+++ b/atoma-service/src/handlers/chat_completions.rs
@@ -908,6 +908,9 @@ async fn handle_streaming_response(
                 endpoint: endpoint.clone(),
             })?;
     if status_code == StatusCode::TOO_MANY_REQUESTS {
+        state
+            .too_many_requests
+            .insert(model.to_string(), Instant::now());
         return Err(AtomaServiceError::ChatCompletionsServiceUnavailable {
             message: "Too many requests".to_string(),
             endpoint: endpoint.clone(),
@@ -1329,6 +1332,9 @@ pub mod utils {
                 endpoint: endpoint.to_string(),
             })?;
         if status_code == StatusCode::TOO_MANY_REQUESTS {
+            state
+                .too_many_requests
+                .insert(model.to_string(), Instant::now());
             return Err(AtomaServiceError::ChatCompletionsServiceUnavailable {
                 message: "Too many requests".to_string(),
                 endpoint: endpoint.to_string(),

--- a/atoma-service/src/handlers/completions.rs
+++ b/atoma-service/src/handlers/completions.rs
@@ -882,6 +882,9 @@ async fn handle_streaming_response(
                 endpoint: endpoint.clone(),
             })?;
     if status_code == StatusCode::TOO_MANY_REQUESTS {
+        state
+            .too_many_requests
+            .insert(model.to_string(), Instant::now());
         return Err(AtomaServiceError::ChatCompletionsServiceUnavailable {
             message: "Too many requests".to_string(),
             endpoint: endpoint.clone(),
@@ -1292,6 +1295,9 @@ pub mod utils {
                 endpoint: endpoint.to_string(),
             })?;
         if status_code == StatusCode::TOO_MANY_REQUESTS {
+            state
+                .too_many_requests
+                .insert(model.to_string(), Instant::now());
             return Err(AtomaServiceError::ChatCompletionsServiceUnavailable {
                 message: "Too many requests".to_string(),
                 endpoint: endpoint.to_string(),

--- a/atoma-service/src/middleware.rs
+++ b/atoma-service/src/middleware.rs
@@ -811,6 +811,15 @@ pub async fn verify_permissions(
             message: "Model is not a string".to_string(),
             endpoint: endpoint.clone(),
         })?;
+    if let Some(trigger_time) = state.too_many_requests.get(model) {
+        if trigger_time.elapsed().as_millis() < state.too_many_requests_timeout_ms {
+            return Err(AtomaServiceError::ChatCompletionsServiceUnavailable {
+                message: "Too many requests".to_string(),
+                endpoint: endpoint.clone(),
+            });
+        }
+        state.too_many_requests.remove(model);
+    }
     if !state.models.contains(&model.to_string()) {
         return Err(AtomaServiceError::InvalidBody {
             message: format!("Model not supported, supported models: {:?}", state.models),

--- a/atoma-service/src/server.rs
+++ b/atoma-service/src/server.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use atoma_confidential::types::{
     ConfidentialComputeDecryptionRequest, ConfidentialComputeDecryptionResponse,
@@ -204,6 +204,12 @@ pub struct AppState {
 
     /// The Sui address of the clients that are allowed to use fiat.
     pub whitelist_sui_addresses_for_fiat: Vec<String>,
+
+    /// When was the too many requests triggered for each model.
+    pub too_many_requests: Arc<DashMap<String, Instant>>,
+
+    /// The time for which we triiger too many requests since the first occurrence.
+    pub too_many_requests_timeout_ms: u128,
 }
 
 /// Creates and configures the main router for the application.

--- a/atoma-service/src/tests.rs
+++ b/atoma-service/src/tests.rs
@@ -341,6 +341,8 @@ mod middleware {
                 address_index: 0,
                 stack_retrieve_sender,
                 whitelist_sui_addresses_for_fiat: vec![],
+                too_many_requests: Arc::new(DashMap::new()),
+                too_many_requests_timeout_ms: 0,
             },
             public_key,
             signature,

--- a/config.example.toml
+++ b/config.example.toml
@@ -43,6 +43,7 @@ models                           = [ "Infermatic/Llama-3.3-70B-Instruct-FP8-Dyna
 revisions                        = [ "main" ]
 sentry_dsn                       = ""                                                  # Sentry DSN (for use in sentry, you need to set the Sentry DSN)
 service_bind_address             = "0.0.0.0:3000"
+too_many_requests_timeout_ms     = 2000                                                # Timeout for too many requests flag in milliseconds
 whitelist_sui_addresses_for_fiat = [  ]                                                # Sui addresses that are allowed to use fiat payments
 
 [atoma_sui]


### PR DESCRIPTION
If too many requests was triggered, respond only too many requests for a period of time defined in the config