### PR TITLE
fix: how check for too many requests is handled

### DIFF
--- a/atoma-service/src/middleware.rs
+++ b/atoma-service/src/middleware.rs
@@ -1674,7 +1674,6 @@ pub mod utils {
                         endpoint: endpoint.to_string(),
                     });
                 }
-                occupied_entry.remove();
             }
             dashmap::mapref::entry::Entry::Vacant(_) => {
                 tracing::debug!(
@@ -1682,6 +1681,7 @@ pub mod utils {
                     level = "debug",
                     "Model is not in the `too_many_requests` map, so no action is needed here. Processing can continue."
                 );
+                return Ok(());
             }
         }
         let chat_completions_service_urls = state
@@ -1714,7 +1714,6 @@ pub mod utils {
                     model
                 );
         } else if !metrics.is_empty() {
-            // TODO: Should we add the model to the `too_many_requests` map here?
             tracing::debug!(
                     target = "atoma-service",
                     level = "debug",


### PR DESCRIPTION
Fix how the too many requests release is handled.
It should not remove the model from the `too_many_requests` just because the timer passed, other check has to pass as well.