### PR TITLE
refactor: replace InferenceRequest with send_and_receive_request in chat and completions handlers

### DIFF
--- a/atoma-service/src/handlers/completions.rs
+++ b/atoma-service/src/handlers/completions.rs
@@ -7,7 +7,7 @@ use crate::{
             TOTAL_FAILED_CHAT_REQUESTS, TOTAL_LOCKED_REQUESTS, TOTAL_TOO_EARLY_REQUESTS,
             TOTAL_TOO_MANY_REQUESTS, TOTAL_UNAUTHORIZED_REQUESTS,
         },
-        request_batcher::InferenceRequest,
+        request_batcher::send_and_receive_request,
         sign_response_and_update_stack_hash, update_fiat_amount, update_stack_num_compute_units,
     },
     middleware::EncryptionMetadata,
@@ -898,54 +898,17 @@ async fn handle_streaming_response(
             endpoint: endpoint.clone(),
         });
     }
-    let (result_sender, result_receiver) = tokio::sync::oneshot::channel();
-    state.request_batcher_sender.send(InferenceRequest {
-            url: format!("{}{}", completions_service_url, COMPLETIONS_PATH),
-            payload: payload.clone(),
-            result_sender
-        }).map_err(|e| {
-            state
-                .running_num_requests
-                .decrement(&completions_service_url);
-            AtomaServiceError::InternalError {
-                message: format!(
-                    "Error sending request to inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
-                    payload_hash,
-                    stack_small_id,
-                    e
-                ),
-                endpoint: endpoint.to_string(),
-            }
-        })?;
-    let response = result_receiver
-            .await
-            .map_err(|e| {
-                state
-                    .running_num_requests
-                    .decrement(&completions_service_url);
-                AtomaServiceError::InternalError {
-                    message: format!(
-                        "Error receiving response from inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
-                        payload_hash,
-                        stack_small_id,
-                        e
-                    ),
-                    endpoint: endpoint.to_string(),
-                }
-            })?.map_err(|e| {
-                state
-                    .running_num_requests
-                    .decrement(&completions_service_url);
-                AtomaServiceError::InternalError {
-                    message: format!(
-                        "Error processing response from inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
-                        payload_hash,
-                        stack_small_id,
-                        e
-                    ),
-                    endpoint: endpoint.to_string(),
-                }
-            })?;
+    let response = send_and_receive_request(
+        &state.request_batcher_sender,
+        &completions_service_url,
+        COMPLETIONS_PATH,
+        &payload,
+        &state.running_num_requests,
+        &payload_hash,
+        stack_small_id,
+        &endpoint,
+    )
+    .await?;
 
     if !response.status().is_success() {
         state
@@ -1135,9 +1098,10 @@ pub mod utils {
     use opentelemetry::KeyValue;
 
     use crate::handlers::{
-        handle_concurrent_requests_count_decrement, handle_status_code_error,
+        completions::COMPLETIONS_PATH, handle_concurrent_requests_count_decrement,
+        handle_status_code_error,
         inference_service_metrics::get_best_available_chat_completions_service_url,
-        metrics::CHAT_COMPLETIONS_LATENCY_METRICS, request_batcher::InferenceRequest,
+        metrics::CHAT_COMPLETIONS_LATENCY_METRICS, request_batcher::send_and_receive_request,
         update_fiat_amount, COMPLETION_TOKENS_KEY, PROMPT_TOKENS_KEY, USAGE_KEY,
     };
 
@@ -1147,7 +1111,7 @@ pub mod utils {
         AtomaServiceError, Body, ConfidentialComputeSharedSecretRequest,
         ConfidentialComputeSharedSecretResponse, EncryptionMetadata, IntoResponse, Json, Response,
         StreamingEncryptionMetadata, Value, CHAT_COMPLETIONS_INPUT_TOKENS_METRICS,
-        CHAT_COMPLETIONS_OUTPUT_TOKENS_METRICS, COMPLETIONS_PATH, MODEL_KEY, UNKNOWN_MODEL,
+        CHAT_COMPLETIONS_OUTPUT_TOKENS_METRICS, MODEL_KEY, UNKNOWN_MODEL,
     };
 
     /// Retrieves encryption metadata for streaming chat completions when confidential compute is enabled.
@@ -1348,55 +1312,17 @@ pub mod utils {
                 endpoint: endpoint.to_string(),
             });
         }
-        let (result_sender, result_receiver) = tokio::sync::oneshot::channel();
-        state.request_batcher_sender.send(InferenceRequest {
-            url: format!("{}{}", completions_service_url, COMPLETIONS_PATH),
-            payload: payload.clone(),
-            result_sender
-        }).map_err(|e| {
-            state
-                .running_num_requests
-                .decrement(&completions_service_url);
-            AtomaServiceError::InternalError {
-                message: format!(
-                    "Error sending request to inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
-                    payload_hash,
-                    stack_small_id,
-                    e
-                ),
-                endpoint: endpoint.to_string(),
-            }
-        })?;
-        let response = result_receiver
-            .await
-            .map_err(|e| {
-                state
-                    .running_num_requests
-                    .decrement(&completions_service_url);
-                AtomaServiceError::InternalError {
-                    message: format!(
-                        "Error receiving response from inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
-                        payload_hash,
-                        stack_small_id,
-                        e
-                    ),
-                    endpoint: endpoint.to_string(),
-                }
-            })?;
-        state
-            .running_num_requests
-            .decrement(&completions_service_url);
-        let response = response.map_err(|e| {
-            AtomaServiceError::InternalError {
-                message: format!(
-                    "Error sending request to inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
-                    payload_hash,
-                    stack_small_id,
-                    e
-                ),
-                endpoint: endpoint.to_string(),
-            }
-        })?;
+        let response = send_and_receive_request(
+            &state.request_batcher_sender,
+            &completions_service_url,
+            COMPLETIONS_PATH,
+            payload,
+            &state.running_num_requests,
+            &payload_hash,
+            stack_small_id,
+            endpoint,
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/atoma-service/src/handlers/request_batcher.rs
+++ b/atoma-service/src/handlers/request_batcher.rs
@@ -9,6 +9,8 @@ use tokio::sync::{
 };
 use tracing::instrument;
 
+use crate::{error::AtomaServiceError, handlers::request_counter::RequestCounter};
+
 // This module provides a batcher for handling inference requests.
 // It allows for batching requests to a specified URL with a given payload and sending the results back to the requester.
 // The batcher processes requests at a specified interval, allowing for efficient handling of multiple requests.
@@ -178,4 +180,80 @@ impl RequestsBatcher {
             .send(result)
             .map_err(|_| InferenceBatcherError::SendResultError)
     }
+}
+
+/// Sends an inference request to the specified URL with the given payload.
+/// This function is used to send requests to the inference service and handle the response.
+/// It returns a `Result` containing the response or an error if the request fails.
+///
+/// # Arguments
+/// * `request_batcher_sender` - The sender channel for the request batcher.
+/// * `url` - The URL to which the request should be sent.
+/// * `path` - The path to append to the URL for the request.
+/// * `payload` - The payload to send with the request, serialized as JSON.
+/// * `running_num_requests` - A reference to a shared counter for tracking running requests.
+/// * `payload_hash` - A hash of the payload for tracking purposes.
+/// * `stack_small_id` - An optional identifier for the stack small.
+/// * `endpoint` - The endpoint for which the request is being sent, used for error reporting.
+///
+/// # Returns
+/// A `Result` containing the response from the inference service or an `AtomaServiceError` if an error occurs.
+#[instrument(level = "debug", skip_all, fields(url = %url, payload_hash = ?payload_hash, stack_small_id = ?stack_small_id))]
+#[allow(clippy::too_many_arguments)]
+pub async fn send_and_receive_request(
+    request_batcher_sender: &mpsc::UnboundedSender<InferenceRequest>,
+    url: &str,
+    path: &str,
+    payload: &Value,
+    running_num_requests: &Arc<RequestCounter>,
+    payload_hash: &[u8; 32],
+    stack_small_id: Option<i64>,
+    endpoint: &str,
+) -> Result<reqwest::Response, AtomaServiceError> {
+    let (result_sender, result_receiver) = tokio::sync::oneshot::channel();
+    request_batcher_sender.send(InferenceRequest {
+            url: format!("{}{}", url, path),
+            payload:payload.clone(),
+            result_sender
+        }).map_err(|e| {
+                running_num_requests
+                .decrement(url);
+            AtomaServiceError::InternalError {
+                message: format!(
+                    "Error sending request to inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
+                    payload_hash,
+                    stack_small_id,
+                    e
+                ),
+                endpoint: endpoint.to_string(),
+            }
+        })?;
+    let response = result_receiver
+            .await
+            .map_err(|e| {
+                running_num_requests
+                    .decrement(url);
+                AtomaServiceError::InternalError {
+                    message: format!(
+                        "Error receiving response from inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
+                        payload_hash,
+                        stack_small_id,
+                        e
+                    ),
+                    endpoint: endpoint.to_string(),
+                }
+            })?.map_err(|e| {
+                running_num_requests
+                    .decrement(url);
+                AtomaServiceError::InternalError {
+                    message: format!(
+                        "Error processing response from inference service, for request with payload hash: {:?}, and stack small id: {:?}, with error: {}",
+                        payload_hash,
+                        stack_small_id,
+                        e
+                    ),
+                    endpoint: endpoint.to_string(),
+                }
+            })?;
+    Ok(response)
 }

--- a/atoma-service/src/handlers/request_batcher.rs
+++ b/atoma-service/src/handlers/request_batcher.rs
@@ -40,8 +40,6 @@ pub struct RequestsBatcher {
 pub enum InferenceBatcherError {
     #[error("Failed to send the result back to the requester")]
     SendResultError,
-    #[error("Failed to acquire the client lock")]
-    ClientLockError,
     #[error("Failed to join the batcher task")]
     JoinError(#[from] tokio::task::JoinError),
 }


### PR DESCRIPTION
This pull request refactors the request handling logic for chat completions and completions services in the `atoma-service` codebase. The primary change introduces a reusable helper function, `send_and_receive_request`, to streamline and centralize the logic for sending inference requests and handling responses. This change improves code readability, reduces duplication, and enhances maintainability.
