### PR TITLE
fix: dockerfile changes for newest sui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     libssl-dev \
     libssl3 \
+    libclang-dev \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add missing `libclang-dev` for newest sui.